### PR TITLE
CI and Function Type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v2
+        with:
+          verbose: true
+          files: lcov.info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'nightly'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ assets/temp
 *.backup
 
 # Ignore Manifest.toml
-Manifest.toml
+./Manifest.toml
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1512,8 +1512,7 @@ function circlepoints(f::FunctionType,n; dir="acw") where {FunctionType <: Funct
     end
 end
 
-function loftlinear(V1,V2;num_steps=2,close_loop=true,face_type="tri")
-    """
+"""
     The `loftlinear` function spans a surface from input curve `V1` to curve 
     `V2`. The surface is formed by "lerping" curves form V1 to V2 in `num_loft` 
     steps, and forming mesh faces between each curve. If `close_loop==true`
@@ -1526,7 +1525,8 @@ function loftlinear(V1,V2;num_steps=2,close_loop=true,face_type="tri")
     The point order here causes normal directions to conform to a surface if 
     the input curves were derived from a surface (in 2D this means "clockwise
      curves" would result in an outward normal surface. 
-    """
+"""
+function loftlinear(V1,V2;num_steps=2,close_loop=true,face_type="tri")
     num_loop = length(V1)
     T = eltype(V1)
     # Linearly blending points from first to last

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1504,7 +1504,7 @@ function circlepoints(r,n; dir="acw")
     end
 end
 
-function circlepoints(f::Function,n; dir="acw")
+function circlepoints(f::FunctionType,n; dir="acw") where {FunctionType <: Function}
     if dir=="acw"
         return [GeometryBasics.Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t ∈ range(0,2*π-(2*π)/n,n)]
     else


### PR DESCRIPTION
In Julia, as we can see

```Julia
julia> typeof(abs)
typeof(abs) (singleton type of function abs, subtype of Function)
```
the function `abs` has a subtype of function so it is better to define 

```julia
function circlepoints(f::FunctionType,n; dir="acw") where {FunctionType <: Function}
    if dir=="acw"
        return [GeometryBasics.Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t ∈ range(0,2*π-(2*π)/n,n)]
    else
        return [GeometryBasics.Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t ∈ range(0,(2*π)/n-2*π,n)]
    end
end
```

rather than

```julia
function circlepoints(f::Function,n; dir="acw")
    if dir=="acw"
        return [GeometryBasics.Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t ∈ range(0,2*π-(2*π)/n,n)]
    else
        return [GeometryBasics.Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t ∈ range(0,(2*π)/n-2*π,n)]
    end
end
```


Addition to this, this PR add GitHub CI workflow.