### PR TITLE
fix multiline comments

### DIFF
--- a/docs/demo_dist.jl
+++ b/docs/demo_dist.jl
@@ -2,12 +2,12 @@ using Comodo
 using GeometryBasics # For point and mesh format
 using GLMakie
 
-"""
+#=
 This demo shows the use of distND to compute distances for ND points. A 3D 
 point set is defined on an icosahedron. Next a refined (using subtri) version is
 created and the distance from the refined to the unrefined are computed. Next
 the minimum distances are visualised on the mesh. 
-"""
+=#
 
 # Defining icosahedron
 r = 1 # radius of icosahedron

--- a/docs/demo_facenormal.jl
+++ b/docs/demo_facenormal.jl
@@ -1,11 +1,11 @@
 using Comodo
 using GLMakie
 
-"""
+#=
 This demo shows the use of the `meshnormal` function to obtain mesh face normal
 directions. The demo shows visualisations for a triangular, quadrilateral, and 
 a pentagonal mesh. 
-"""
+=#
 
 fig = Figure(size=(1600,800))
 

--- a/docs/demo_geosphere.jl
+++ b/docs/demo_geosphere.jl
@@ -2,11 +2,11 @@ using Comodo
 using GLMakie
 using GeometryBasics
 
-"""
+#=
 This demo shows the use of the geosphere function. An unrefined sphere is an 
 icosahedron. Through subdivision (see `subtri`) a refined geodesic dome is 
 obtained. 
-"""
+=#
 
 r = 1.0 # radius
 n1 = 0 # Number of refinement iterations

--- a/docs/demo_gridpoints.jl
+++ b/docs/demo_gridpoints.jl
@@ -3,10 +3,10 @@ using GLMakie
 using GeometryBasics
 using LinearAlgebra
 
-"""
+#=
 This demo shows the use of the gridpoints function. This function can be used to create
 a grid of points. 
-"""
+=#
 
 
 # Define a set of points on a grid using a range, y and z are assumed equal to x when not provided

--- a/docs/demo_interp_biharmonic.jl
+++ b/docs/demo_interp_biharmonic.jl
@@ -3,11 +3,11 @@ using GLMakie
 using GeometryBasics
 using Random
 
-"""
+#=
 In this demo biharmonic interpolation is used for 3D scattered data 
 interpolation. First a set of random 3D points and "value data" is defined. Next
 a grid of points are defined onto which this value data is interpolated. 
-"""
+=#
 
 Random.seed!(1) # Set seed so demo performs the same each time
 

--- a/docs/demo_interp_biharmonic_spline.jl
+++ b/docs/demo_interp_biharmonic_spline.jl
@@ -1,9 +1,9 @@
 using Comodo
 using GLMakie
 
-"""
-This demo shows the use of interp_biharmonic_spline for curve interpolation. 
-"""
+
+# This demo shows the use of interp_biharmonic_spline for curve interpolation. 
+
 
 # Define raw data
 x = range(0,9,9) # Interval definition

--- a/docs/demo_mergevertices.jl
+++ b/docs/demo_mergevertices.jl
@@ -4,9 +4,9 @@ using GeometryBasics
 using FileIO
 using Statistics
 
-"""
-Demonstration of the mergevertices function
-"""
+
+# Demonstration of the mergevertices function
+
 # Loading a mesh
 fileName_mesh = joinpath(comododir(),"assets","stl","stanford_bunny_low.stl")
 M1 = load(fileName_mesh)

--- a/docs/demo_mindist.jl
+++ b/docs/demo_mindist.jl
@@ -2,12 +2,12 @@ using Comodo
 using GeometryBasics # For point and mesh format
 using GLMakie
 
-"""
+#=
 This demo shows the use of distND to compute distances for ND points. A 3D 
 point set is defined on an icosahedron. Next a refined (using subtri) version is
 created and the distance from the refined to the unrefined are computed. Next
 the minimum distances are visualised on the mesh. 
-"""
+=#
 
 # Defining icosahedron
 r = 1 # radius of icosahedron

--- a/docs/demo_nbezier.jl
+++ b/docs/demo_nbezier.jl
@@ -2,9 +2,9 @@ using Comodo
 using GeometryBasics
 using GLMakie
 
-"""
-This demo shows the use of nbezier for Bezier curve interpolation. 
-"""
+
+# This demo shows the use of nbezier for Bezier curve interpolation. 
+
 
 # Define raw data
 P = Vector{GeometryBasics.Point{3, Float64}}(undef,4)

--- a/docs/demo_rotate_mesh.jl
+++ b/docs/demo_rotate_mesh.jl
@@ -4,11 +4,11 @@ using GeometryBasics
 using FileIO
 using Rotations
 
-"""
+#=
 In this demo a mesh is loaded, in this case a triangulated surface from an STL 
 file. Next the coordinates are rotated, and the unrotated and rotated meshes 
 are visualized. 
-"""
+=#
 
 # Loading a mesh
 fileName_mesh = joinpath(comododir(),"assets","stl","stanford_bunny_low.stl")

--- a/docs/demo_spline_interpolation_1D.jl
+++ b/docs/demo_spline_interpolation_1D.jl
@@ -2,9 +2,8 @@ using Comodo
 using GLMakie
 using BSplineKit
 
-"""
-This demo shows the use of the BSplineKit package for spline based curve interpolation. 
-"""
+# This demo shows the use of the BSplineKit package for spline based curve interpolation. 
+
 
 # Define raw data
 x = range(0,9,9) # Interval definition

--- a/docs/demo_subtri.jl
+++ b/docs/demo_subtri.jl
@@ -2,7 +2,7 @@ using Comodo
 using GLMakie
 using GeometryBasics
 
-"""
+#=
 This demo shows the use of `subtri` to refine triangulated meshes. Each 
 original input triangle spawns 4 triangles for the regined mesh (one central 
 one, and 3 at each corner). The following refinement methods are implemented: 
@@ -17,7 +17,7 @@ one, and 3 at each corner). The following refinement methods are implemented:
     such that the surface effectively approaches a "quartic box spline". Hence 
     this method both refines and smoothes the geometry through spline 
     approximation. 
-"""
+=#
 
 ## Define example input
 r = 0.5 #radius

--- a/docs/demo_vertexnormal.jl
+++ b/docs/demo_vertexnormal.jl
@@ -4,11 +4,11 @@ using Statistics
 using GeometryBasics
 using FileIO
 
-"""
+#=
 This demo shows the use of the `meshnormal` function to obtain mesh face normal
 directions. The demo shows visualisations for a triangular, quadrilateral, and 
 a pentagonal mesh. 
-"""
+=#
 
 fig = Figure(size=(1600,800))
 


### PR DESCRIPTION
We can use 

```julia
#= .....
..........
..........
=#
```

for multi-line comments. Using multiline strings rather than comments allocates memory on the global scope, which is not recommended. We can use multiple line string for docstrings which in turn will be used by the help system and Documenter.jl.

The next step is to move examples into an `example` directory, because docs if generally used for the markdown documentation in Julia packages.