### PR TITLE
add coverage task in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: >
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=. -e 'using Pkg; Pkg.activate("."); Pkg.test()'
+      - uses: codecov/codecov-action@v2
+        with:
+          verbose: true
+          files: lcov.info


### PR DESCRIPTION
- Add task for coverage in CI

Note:

Badge is automatically generated by `https://app.codecov.io/login`. A new account should be created and the main repository should be linked to generate a badge.