### PR TITLE
Change Int64 -> Int

### DIFF
--- a/examples/demo_boundaryfaces.jl
+++ b/examples/demo_boundaryfaces.jl
@@ -12,7 +12,7 @@ if testCase == 1
     sampleSize = 10
     pointSpacing = 2
     boxDim = sampleSize.*[1,1,1] # Dimensionsions for the box in each direction
-    boxEl = ceil.(Int64,boxDim./pointSpacing) # Number of elements to use in each direction 
+    boxEl = ceil.(Int,boxDim./pointSpacing) # Number of elements to use in each direction 
     E,V,F,Fb,CFb_type = hexbox(boxDim,boxEl)    
 elseif testCase == 2
     F1,V1 = geosphere(3,1.0)

--- a/examples/demo_distmarch.jl
+++ b/examples/demo_distmarch.jl
@@ -14,8 +14,8 @@ if testCase == 1
     V[2 ] = GeometryBasics.Point{3, Float64}( 0.0,   -s, 0.0)
     V[3 ] = GeometryBasics.Point{3, Float64}(   s,  0.0, 0.0)
 
-    F = Vector{TriangleFace{Int64}}(undef,1)
-    F[1 ] = TriangleFace{Int64}(1,2,3)
+    F = Vector{TriangleFace{Int}}(undef,1)
+    F[1 ] = TriangleFace{Int}(1,2,3)
     # F,V=subtri(F,V,2)
 elseif testCase==2
     # Bowtie mesh
@@ -27,9 +27,9 @@ elseif testCase==2
     V[4 ] = GeometryBasics.Point{3, Float64}( 2*s,    s, 0.0)
     V[5 ] = GeometryBasics.Point{3, Float64}( 2*s,    -s, 0.0)
 
-    F = Vector{TriangleFace{Int64}}(undef,2)
-    F[1 ] = TriangleFace{Int64}(1,2,3)
-    F[2 ] = TriangleFace{Int64}(5,4,3)
+    F = Vector{TriangleFace{Int}}(undef,2)
+    F[1 ] = TriangleFace{Int}(1,2,3)
+    F[2 ] = TriangleFace{Int}(5,4,3)
     # F,V=subtri(F,V,2)
 elseif testCase==3
     r = 1.0

--- a/examples/demo_extrudecurve.jl
+++ b/examples/demo_extrudecurve.jl
@@ -14,7 +14,7 @@ d = 3.0 # Extrusion distance (extent)
 n = normalizevector(Vec{3, Float64}(0.0,0.0,1.0)) # Extrusion direction
 direction = :positive
 
-#   num_steps = ceil(Int64,d/pointSpacing)
+#   num_steps = ceil(Int,d/pointSpacing)
 
 F1,V1 = extrudecurve(Vc; extent=d, direction=:positive, n=n, close_loop=true,face_type=:quad)
 F2,V2 = extrudecurve(Vc; extent=d, direction=:both, n=n, close_loop=true,face_type=:tri_slash)

--- a/examples/demo_hexbox.jl
+++ b/examples/demo_hexbox.jl
@@ -10,7 +10,7 @@ domain.
 sampleSize = 10
 pointSpacing = 2
 boxDim = sampleSize.*[1,1,1] # Dimensionsions for the box in each direction
-boxEl = ceil.(Int64,boxDim./pointSpacing) # Number of elements to use in each direction 
+boxEl = ceil.(Int,boxDim./pointSpacing) # Number of elements to use in each direction 
 
 E,V,F,Fb,CFb_type = hexbox(boxDim,boxEl)
 
@@ -37,7 +37,7 @@ ZE = [v[3] for v in VE]
 Z = [v[3] for v in V]
 zMax = maximum(Z)
 zMin = minimum(Z)
-numSlicerSteps = 3*ceil(Int64,(zMax-zMin)/mean(edgelengths(F,V)))
+numSlicerSteps = 3*ceil(Int,(zMax-zMin)/mean(edgelengths(F,V)))
 
 stepRange = range(zMin,zMax,numSlicerSteps)
 hSlider = Slider(fig[2, 1], range = stepRange, startvalue = mean(stepRange),linewidth=30)

--- a/examples/demo_mesh_curvature_polynomial.jl
+++ b/examples/demo_mesh_curvature_polynomial.jl
@@ -21,11 +21,11 @@ elseif testCase==3
 elseif testCase==4   
     r = 25
     s = r/10
-    nc = round(Int64,(2*pi*r)/s)
+    nc = round(Int,(2*pi*r)/s)
     d = r*2
     Vc = circlepoints(r, nc; dir=:cw)
-    num_steps = round(Int64,d/s)
-    num_steps = num_steps + Int64(iseven(num_steps))
+    num_steps = round(Int,d/s)
+    num_steps = num_steps + Int(iseven(num_steps))
     F, V = extrudecurve(Vc, d; s=1, n=[0.0,0.0,1.0], num_steps=num_steps, close_loop=true, face_type=:quad)
 elseif testCase==5 # Merged STL for single object
     # Loading a mesh

--- a/examples/demo_meshgroup.jl
+++ b/examples/demo_meshgroup.jl
@@ -11,8 +11,8 @@ if testCase == 1
     V[2 ] = GeometryBasics.Point{3, Float64}( 0.0,   -s, 0.0)
     V[3 ] = GeometryBasics.Point{3, Float64}(   s,  0.0, 0.0)
 
-    F = Vector{TriangleFace{Int64}}(undef,1)
-    F[1 ] = TriangleFace{Int64}(1,2,3)
+    F = Vector{TriangleFace{Int}}(undef,1)
+    F[1 ] = TriangleFace{Int}(1,2,3)
     # F,V=subtri(F,V,2)
 elseif testCase==2
     s=1.0
@@ -23,9 +23,9 @@ elseif testCase==2
     V[4 ] = GeometryBasics.Point{3, Float64}( 2*s,    s, 0.0)
     V[5 ] = GeometryBasics.Point{3, Float64}( 2*s,    -s, 0.0)
 
-    F = Vector{TriangleFace{Int64}}(undef,2)
-    F[1 ] = TriangleFace{Int64}(1,2,3)
-    F[2 ] = TriangleFace{Int64}(3,4,5)
+    F = Vector{TriangleFace{Int}}(undef,2)
+    F[1 ] = TriangleFace{Int}(1,2,3)
+    F[2 ] = TriangleFace{Int}(3,4,5)
     # F,V=subtri(F,V,2)
 elseif testCase==3
     r = 1.0

--- a/examples/demo_sweeploft.jl
+++ b/examples/demo_sweeploft.jl
@@ -242,7 +242,7 @@ linewidth = 2
 
 if vizCase ==1 
 
-    CF = round.(Int64,vertex2simplexdata(F,C))
+    CF = round.(Int,vertex2simplexdata(F,C))
 
     fig = Figure(size = (1600,1600))
     ax = Axis3(fig[1, 1],aspect = :data,title="Swept lofting")

--- a/examples/demo_tet2hex.jl
+++ b/examples/demo_tet2hex.jl
@@ -10,7 +10,7 @@ domain.
 testCase = 1
 
 if testCase == 1
-    E = [Tet4{Int64}(1,2,3,4),Tet4{Int64}(2,3,4,5),Tet4{Int64}(6,7,8,9)]
+    E = [Tet4{Int}(1,2,3,4),Tet4{Int}(2,3,4,5),Tet4{Int}(6,7,8,9)]
     V = [Point{3,Float64}(-1.0,0.0,0.0),
          Point{3,Float64}( 1.0,0.0,0.0),
          Point{3,Float64}( 0.0,1.0,0.0),
@@ -22,7 +22,7 @@ if testCase == 1
          Point{3,Float64}( 3.0,0.5,1.0),
          ]
 elseif testCase == 2
-    E = [hex8{Int64}(1,2,3,4,5,6,7,8)]
+    E = [hex8{Int}(1,2,3,4,5,6,7,8)]
     V = [Point{3,Float64}(0.0,0.0,0.0),
          Point{3,Float64}(1.0,0.0,0.0),
          Point{3,Float64}(1.0,1.0,0.0),

--- a/examples/demo_tetgenmesh.jl
+++ b/examples/demo_tetgenmesh.jl
@@ -156,7 +156,7 @@ ZE = [v[3] for v in VE]
 Z = [v[3] for v in V]
 zMax = maximum(Z)
 zMin = minimum(Z)
-numSlicerSteps = 3*ceil(Int64,(zMax-zMin)/mean(edgelengths(F,V)))
+numSlicerSteps = 3*ceil(Int,(zMax-zMin)/mean(edgelengths(F,V)))
 
 stepRange = range(zMin,zMax,numSlicerSteps)
 hSlider = Slider(fig[2, 1], range = stepRange, startvalue = mean(stepRange),linewidth=30)

--- a/examples/demo_tetvol.jl
+++ b/examples/demo_tetvol.jl
@@ -167,7 +167,7 @@ ZE = [v[3] for v in VE]
 Z = [v[3] for v in V]
 zMax = maximum(Z)
 zMin = minimum(Z)
-numSlicerSteps = 3*ceil(Int64,(zMax-zMin)/mean(edgelengths(F,V)))
+numSlicerSteps = 3*ceil(Int,(zMax-zMin)/mean(edgelengths(F,V)))
 
 stepRange = range(zMin,zMax,numSlicerSteps)
 hSlider = Slider(fig[2, 1], range = stepRange, startvalue = mean(stepRange),linewidth=30)

--- a/examples/demo_tri2quad.jl
+++ b/examples/demo_tri2quad.jl
@@ -14,10 +14,10 @@ connecting the original vertices to new mid-edge and mid-face vertices.
 testCase = 3
 if testCase == 1 # Single triangle
     V = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(1.0,1.0,0.0)]
-    F = [TriangleFace{Int64}(1,2,3)]
+    F = [TriangleFace{Int}(1,2,3)]
 elseif testCase == 2 # Single triangle refined once, so 4 triangles
     V = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(0.0,1.0,0.0),Point{3,Float64}(1.0,1.0,0.0)]
-    F = [TriangleFace{Int64}(1,2,3),TriangleFace{Int64}(2,4,3)]
+    F = [TriangleFace{Int}(1,2,3),TriangleFace{Int}(2,4,3)]
     F,V = subtri(F,V,1)
 elseif testCase == 3 # tetrahedron
     r = 0.5 #radius
@@ -41,7 +41,7 @@ end
 
 Fq,Vq = tri2quad(F,V; method=:split)
 Fr,Vr = tri2quad(F,V; method=:rhombic)
-# Fr = [QuadFace{Int64}(f[2],f[3],f[4],f[1]) for f in Fr]
+# Fr = [QuadFace{Int}(f[2],f[3],f[4],f[1]) for f in Fr]
 
 ## Visualization
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -31,17 +31,17 @@ const Penta6{T} = Element{6,T} where T<:Integer
 A struct featuring the connectivity data for a mesh.   
 """
 struct ConnectivitySet
-    edge_vertex::Vector{LineFace{Int64}}
-    edge_face::Vector{Vector{Int64}}
-    edge_edge::Vector{Vector{Int64}}
-    face_vertex#::Vector{Vector{Int64}} # Could be triangle/quad etc
-    face_edge::Vector{Vector{Int64}}        
-    face_face::Vector{Vector{Int64}}
-    vertex_edge::Vector{Vector{Int64}}
-    vertex_face::Vector{Vector{Int64}}        
-    vertex_vertex::Vector{Vector{Int64}}
-    vertex_vertex_f::Vector{Vector{Int64}}
-    face_face_v::Vector{Vector{Int64}}
+    edge_vertex::Vector{LineFace{Int}}
+    edge_face::Vector{Vector{Int}}
+    edge_edge::Vector{Vector{Int}}
+    face_vertex#::Vector{Vector{Int}} # Could be triangle/quad etc
+    face_edge::Vector{Vector{Int}}        
+    face_face::Vector{Vector{Int}}
+    vertex_edge::Vector{Vector{Int}}
+    vertex_face::Vector{Vector{Int}}        
+    vertex_vertex::Vector{Vector{Int}}
+    vertex_vertex_f::Vector{Vector{Int}}
+    face_face_v::Vector{Vector{Int}}
     ConnectivitySet(E_uni, con_E2F, con_E2E, F,  con_F2E, con_F2F, con_V2E, con_V2F, con_V2V, con_V2V_f, con_F2F_v) = new(E_uni, con_E2F, con_E2E, F,  con_F2E, con_F2F, con_V2E, con_V2F, con_V2V, con_V2V_f, con_F2F_v) 
 end
 
@@ -123,7 +123,7 @@ function slider2anim(fig::Figure,hSlider::Slider,fileName::String; backforth=tru
     if backforth
         append!(stepRange,reverse(stepRange[2:end-1]))
     end
-    framerate = ceil(Int64,length(stepRange)/duration)
+    framerate = ceil(Int,length(stepRange)/duration)
     record(fig, fileName, stepRange; framerate = framerate) do stepIndex
         set_close_to!(hSlider, stepIndex)
     end
@@ -209,7 +209,7 @@ function gridpoints_equilateral(xSpan::Union{Vector{TT},Tuple{TT,TT}},ySpan::Uni
     maxY = maximum(ySpan)
 
     wx = maxX - minX
-    nx = ceil(Int64,wx./pointSpacing)+1 # Number of points in the x-direction
+    nx = ceil(Int,wx./pointSpacing)+1 # Number of points in the x-direction
     xRange = range(minX,maxX,nx) # The xRange
     pointSpacingReal_X=xRange[2]-xRange[1]
 
@@ -242,21 +242,21 @@ function gridpoints_equilateral(xSpan::Union{Vector{TT},Tuple{TT,TT}},ySpan::Uni
     # Creat output, including faces if requested
     if return_faces == true
         plateElem=[length(xRange)-1,length(yRange)-1]
-        F = Vector{TriangleFace{Int64}}(undef,prod(plateElem)*2)
+        F = Vector{TriangleFace{Int}}(undef,prod(plateElem)*2)
         num_x = length(xRange)
         ij2ind(i,j) = i + ((j-1)*num_x) # function to convert subscript to linear indices    
         c = 1
         for i = 1:plateElem[1]
             for j = 1:plateElem[2]      
                 if iseven(j)  
-                    F[c] = TriangleFace{Int64}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i+1,j+1)])
+                    F[c] = TriangleFace{Int}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i+1,j+1)])
                     c += 1
-                    F[c] = TriangleFace{Int64}([ij2ind(i+1,j+1),ij2ind(i,j+1),ij2ind(i,j)])
+                    F[c] = TriangleFace{Int}([ij2ind(i+1,j+1),ij2ind(i,j+1),ij2ind(i,j)])
                     c += 1
                 else
-                    F[c] = TriangleFace{Int64}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i,j+1)])
+                    F[c] = TriangleFace{Int}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i,j+1)])
                     c += 1
-                    F[c] = TriangleFace{Int64}([ij2ind(i+1,j),ij2ind(i+1,j+1),ij2ind(i,j+1)])
+                    F[c] = TriangleFace{Int}([ij2ind(i+1,j),ij2ind(i+1,j+1),ij2ind(i,j+1)])
                     c += 1
                 end
             end
@@ -542,7 +542,7 @@ function mindist(V1,V2; getIndex=false, skipSelf = false )
     D = Vector{Float64}(undef,length(V1))
     d = Vector{Float64}(undef,length(V2))
     if getIndex
-        I = Vector{Int64}(undef,length(V1))
+        I = Vector{Int}(undef,length(V1))
     end
     for i in eachindex(V1)
         for j in eachindex(V2)
@@ -584,7 +584,7 @@ function unique_dict_index(X::Union{Array{T},Tuple{T}}; sort_entries=false) wher
     # T = eltype(X)
     d = Dict{T,Nothing}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    indUnique = Vector{Int64}() 
+    indUnique = Vector{Int}() 
     for i in eachindex(X)        
         if sort_entries && length(X[1])>1
             x = sort(X[i])
@@ -618,10 +618,10 @@ function unique_dict_index_inverse(X::Union{Array{T},Tuple{T}}; sort_entries=fal
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
     # Hence the unique indices need to seperately be tracked. 
     # T = eltype(X)
-    d = Dict{T,Int64}() # Use dict to keep track of used values
+    d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    indUnique = Vector{Int64}() 
-    indInverse = Vector{Int64}(undef,length(X)) 
+    indUnique = Vector{Int}() 
+    indInverse = Vector{Int}(undef,length(X)) 
     j=0
     for i in eachindex(X)         
         if sort_entries && length(X[1])>1
@@ -661,10 +661,10 @@ function unique_dict_index_count(X::Union{Array{T},Tuple{T}}; sort_entries=false
     # Hence the unique indices need to seperately be tracked. 
     
     # T = eltype(X)
-    d = Dict{T,Int64}() # Use dict to keep track of used values
+    d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    indUnique = Vector{Int64}() 
-    c =  Vector{Int64}() 
+    indUnique = Vector{Int}() 
+    c =  Vector{Int}() 
 
     j=0
     for i in eachindex(X)      
@@ -705,11 +705,11 @@ function unique_dict_index_inverse_count(X::Union{Array{T},Tuple{T}}; sort_entri
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
     # Hence the unique indices need to seperately be tracked. 
     # T = eltype(X)
-    d = Dict{T,Int64}() # Use dict to keep track of used values
+    d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    indUnique = Vector{Int64}() 
-    indInverse = Vector{Int64}(undef,length(X)) 
-    c =  Vector{Int64}() 
+    indUnique = Vector{Int}() 
+    indInverse = Vector{Int}(undef,length(X)) 
+    c =  Vector{Int}() 
 
     j=0
     for i in eachindex(X)      
@@ -751,9 +751,9 @@ function unique_dict_count(X::Union{Array{T},Tuple{T}}; sort_entries=false) wher
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
     # Hence the unique indices need to seperately be tracked. 
     # T = eltype(X)
-    d = Dict{T,Int64}() # Use dict to keep track of used values
+    d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    c = Vector{Int64}()
+    c = Vector{Int}()
     j = 0
     for i in eachindex(X)      
         if sort_entries && length(X[1])>1
@@ -791,9 +791,9 @@ function unique_dict_inverse(X::Union{Array{T},Tuple{T}}; sort_entries=false) wh
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
     # Hence the unique indices need to seperately be tracked. 
     # T = eltype(X)
-    d = Dict{T,Int64}() # Use dict to keep track of used values
+    d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
-    indInverse = Vector{Int64}(undef,length(X)) 
+    indInverse = Vector{Int}(undef,length(X)) 
 
     j=0
     for i in eachindex(X)      
@@ -826,9 +826,9 @@ Returns the unique entries in `X` as well as the indices for them and the revers
 indices to retrieve the original from the unique entries. 
 """
 function unique_dict(X::AbstractVector{T}) where T <: Real    
-    d = OrderedDict{T ,Int64}() # Use dict to keep track of used values    
-    indUnique = Vector{Int64}()
-    indReverse = Vector{Int64}(undef,length(X))
+    d = OrderedDict{T ,Int}() # Use dict to keep track of used values    
+    indUnique = Vector{Int}()
+    indReverse = Vector{Int}(undef,length(X))
     j=0
     for i in eachindex(X)        
         if !haskey(d, X[i])                                          
@@ -857,7 +857,7 @@ sorted, in this case and entry [3,1,2] is viewed as the same as [1,3,2] and
 [1,2,3] and so on. 
 """
 function occursonce(X::Union{Array{T},Tuple{T}}; sort_entries=false) where T <: Any    
-    d = Dict{T,Int64}() # Use dict to keep track of used values    
+    d = Dict{T,Int}() # Use dict to keep track of used values    
     B = fill(false,length(X))
     for i in eachindex(X)      
         if sort_entries && length(X[1])>1
@@ -940,7 +940,7 @@ function unique_simplices(F,V=nothing)
     else
         n = length(V)
     end
-    virtualFaceIndices = sub2ind(n.*ones(Int64,length(F[1])),sort.(F))    
+    virtualFaceIndices = sub2ind(n.*ones(Int,length(F[1])),sort.(F))    
     _, ind1, ind2 = unique_dict(virtualFaceIndices) 
 
     return F[ind1], ind1, ind2
@@ -957,7 +957,7 @@ Converts linear indices to subscript indices.
 Converts the linear indices in `ind`, for a matrix/array with size `siz`, to the 
 equivalent subscript indices.  
 """
-function ind2sub(siz::Union{Tuple{Vararg{Int64, N}}, Array{Int64, N}},ind::Union{Int64,Tuple{Vararg{Int64, M}}, Array{Int64, M}}) where N where M
+function ind2sub(siz::Union{Tuple{Vararg{Int, N}}, Array{Int, N}},ind::Union{Int,Tuple{Vararg{Int, M}}, Array{Int, M}}) where N where M
     if !isempty(ind) # Not empty so subscript indices will be derived
         numDim = length(siz) # Number of dimensions from length of size
         k = cumprod(siz) # Cumulative product of size
@@ -971,14 +971,14 @@ function ind2sub(siz::Union{Tuple{Vararg{Int64, N}}, Array{Int64, N}},ind::Union
             A = ind2sub_(ind,numDim,k)      
         end
     else # Empty so return an empty vector
-        A = Vector{Int64}[]
+        A = Vector{Int}[]
     end
     return A
 end
 
 # ind2sub helper function to parse just a single linear index and produce a single subscript index set 
-function ind2sub_(ind::Int64,numDim::Int64,k::Union{Int64,Array{Int64, N},Tuple{Vararg{Int64, N}}}) where N
-    a = Vector{Int64}(undef,numDim) # Initialise a
+function ind2sub_(ind::Int,numDim::Int,k::Union{Int,Array{Int, N},Tuple{Vararg{Int, N}}}) where N
+    a = Vector{Int}(undef,numDim) # Initialise a
     for q in numDim:-1:1   # For all dimensions     
         if isone(q) # First 1st dimension
             a[1] = rem(ind-1,k[1]) + 1        
@@ -1002,10 +1002,10 @@ Converts subscript indices to linear indices.
 Converts the subscript indices in `A`, for a matrix/array with size `siz`, to 
 the equivalent linear indices.  
 """
-function sub2ind(siz::Union{Tuple{Vararg{Int64, N}}, Array{Int64, N}},A::Union{Vector{Vector{Int64}}, Array{NgonFace{M, Int64}, 1}}) where N where M
+function sub2ind(siz::Union{Tuple{Vararg{Int, N}}, Array{Int, N}},A::Union{Vector{Vector{Int}}, Array{NgonFace{M, Int}, 1}}) where N where M
     numDim = length(siz)
     k = cumprod([siz[i] for i in eachindex(siz)],dims=1)        
-    ind = Vector{Int64}(undef,length(A))
+    ind = Vector{Int}(undef,length(A))
     for i in eachindex(A)        
         a = A[i]
         if length(a)==numDim
@@ -1020,7 +1020,7 @@ function sub2ind(siz::Union{Tuple{Vararg{Int64, N}}, Array{Int64, N}},A::Union{V
     return ind
 end
 
-function sub2ind(siz::Union{Tuple{Vararg{Int64, N}}, Vector{Int64}},A::Vector{Int64})  where N  
+function sub2ind(siz::Union{Tuple{Vararg{Int, N}}, Vector{Int}},A::Vector{Int})  where N  
     numDim = length(siz)  
     if length(A)==numDim
         if any(A.>siz) || any(A.<1)
@@ -1032,7 +1032,7 @@ function sub2ind(siz::Union{Tuple{Vararg{Int64, N}}, Vector{Int64}},A::Vector{In
     return sub2ind(siz,[A])[1]
 end
 
-function sub2ind_(a::Union{Tuple{Vararg{Int64, N}}, Vector{Int64},NgonFace{M, Int64}},numDim::Int64,k::Union{Int64,Vector{Int64},Tuple{Vararg{Int64, N}}})  where N where M
+function sub2ind_(a::Union{Tuple{Vararg{Int, N}}, Vector{Int},NgonFace{M, Int}},numDim::Int,k::Union{Int,Vector{Int},Tuple{Vararg{Int, N}}})  where N where M
     if numDim==1 
         ind = a[1]
     else        
@@ -1106,27 +1106,27 @@ function icosahedron(r=1.0)
     V[12] = Point{3, Float64}(  -t,  0.0,   s)
 
     # Create faces
-    F = Vector{TriangleFace{Int64}}(undef,20)
-    F[1 ] = TriangleFace{Int64}(9,4,1)
-    F[2 ] = TriangleFace{Int64}(1,5,9)
-    F[3 ] = TriangleFace{Int64}(1,8,5)
-    F[4 ] = TriangleFace{Int64}(10,8,1)
-    F[5 ] = TriangleFace{Int64}(4,10,1)
-    F[6 ] = TriangleFace{Int64}(5,2,12)
-    F[7 ] = TriangleFace{Int64}(12,2,3)
-    F[8 ] = TriangleFace{Int64}(12,3,6)
-    F[9 ] = TriangleFace{Int64}(12,6,9)
-    F[10] = TriangleFace{Int64}(12,9,5)
-    F[11] = TriangleFace{Int64}(10,7,11)
-    F[12] = TriangleFace{Int64}(8,10,11)
-    F[13] = TriangleFace{Int64}(2,8,11)
-    F[14] = TriangleFace{Int64}(3,2,11)
-    F[15] = TriangleFace{Int64}(7,3,11)
-    F[16] = TriangleFace{Int64}(2,5,8)
-    F[17] = TriangleFace{Int64}(10,4,7)
-    F[18] = TriangleFace{Int64}(7,6,3)
-    F[19] = TriangleFace{Int64}(6,7,4)
-    F[20] = TriangleFace{Int64}(6,4,9)
+    F = Vector{TriangleFace{Int}}(undef,20)
+    F[1 ] = TriangleFace{Int}(9,4,1)
+    F[2 ] = TriangleFace{Int}(1,5,9)
+    F[3 ] = TriangleFace{Int}(1,8,5)
+    F[4 ] = TriangleFace{Int}(10,8,1)
+    F[5 ] = TriangleFace{Int}(4,10,1)
+    F[6 ] = TriangleFace{Int}(5,2,12)
+    F[7 ] = TriangleFace{Int}(12,2,3)
+    F[8 ] = TriangleFace{Int}(12,3,6)
+    F[9 ] = TriangleFace{Int}(12,6,9)
+    F[10] = TriangleFace{Int}(12,9,5)
+    F[11] = TriangleFace{Int}(10,7,11)
+    F[12] = TriangleFace{Int}(8,10,11)
+    F[13] = TriangleFace{Int}(2,8,11)
+    F[14] = TriangleFace{Int}(3,2,11)
+    F[15] = TriangleFace{Int}(7,3,11)
+    F[16] = TriangleFace{Int}(2,5,8)
+    F[17] = TriangleFace{Int}(10,4,7)
+    F[18] = TriangleFace{Int}(7,6,3)
+    F[19] = TriangleFace{Int}(6,7,4)
+    F[20] = TriangleFace{Int}(6,4,9)
     
     return GeometryBasics.Mesh(V,F)
 end
@@ -1156,15 +1156,15 @@ function octahedron(r=1.0)
     V[6 ] = Point{3, Float64}(  0.0,   0.0,    r)
     
     # Create faces
-    F = Vector{TriangleFace{Int64}}(undef,8)
-    F[1 ] = TriangleFace{Int64}(5,2,1)
-    F[2 ] = TriangleFace{Int64}(5,3,2)
-    F[3 ] = TriangleFace{Int64}(5,4,3)
-    F[4 ] = TriangleFace{Int64}(5,1,4)
-    F[5 ] = TriangleFace{Int64}(6,1,2)
-    F[6 ] = TriangleFace{Int64}(6,2,3)
-    F[7 ] = TriangleFace{Int64}(6,3,4)
-    F[8 ] = TriangleFace{Int64}(6,4,1)
+    F = Vector{TriangleFace{Int}}(undef,8)
+    F[1 ] = TriangleFace{Int}(5,2,1)
+    F[2 ] = TriangleFace{Int}(5,3,2)
+    F[3 ] = TriangleFace{Int}(5,4,3)
+    F[4 ] = TriangleFace{Int}(5,1,4)
+    F[5 ] = TriangleFace{Int}(6,1,2)
+    F[6 ] = TriangleFace{Int}(6,2,3)
+    F[7 ] = TriangleFace{Int}(6,3,4)
+    F[8 ] = TriangleFace{Int}(6,4,1)
     
     return GeometryBasics.Mesh(V,F)
 end
@@ -1211,19 +1211,19 @@ function dodecahedron(r=1.0)
     V[20] = Point{3, Float64}( 0.0,   t,   w)
 
     # Create faces
-    F = Vector{NgonFace{5,Int64}}(undef,12)
-    F[1 ] = NgonFace{5,Int64}(20, 9,16, 2, 1)
-    F[2 ] = NgonFace{5,Int64}( 2,16,10,14, 8)
-    F[3 ] = NgonFace{5,Int64}(16, 9, 7, 3,10)
-    F[4 ] = NgonFace{5,Int64}( 7, 9,20,15, 5)
-    F[5 ] = NgonFace{5,Int64}(18,13, 3, 7, 5)
-    F[6 ] = NgonFace{5,Int64}( 3,13, 6,14,10)
-    F[7 ] = NgonFace{5,Int64}( 6,13,18,12,11)
-    F[8 ] = NgonFace{5,Int64}( 6,11,17, 8,14)
-    F[9 ] = NgonFace{5,Int64}(11,12,19, 4,17)
-    F[10] = NgonFace{5,Int64}( 1, 2, 8,17, 4)
-    F[11] = NgonFace{5,Int64}( 1, 4,19,15,20)
-    F[12] = NgonFace{5,Int64}(12,18, 5,15,19)
+    F = Vector{NgonFace{5,Int}}(undef,12)
+    F[1 ] = NgonFace{5,Int}(20, 9,16, 2, 1)
+    F[2 ] = NgonFace{5,Int}( 2,16,10,14, 8)
+    F[3 ] = NgonFace{5,Int}(16, 9, 7, 3,10)
+    F[4 ] = NgonFace{5,Int}( 7, 9,20,15, 5)
+    F[5 ] = NgonFace{5,Int}(18,13, 3, 7, 5)
+    F[6 ] = NgonFace{5,Int}( 3,13, 6,14,10)
+    F[7 ] = NgonFace{5,Int}( 6,13,18,12,11)
+    F[8 ] = NgonFace{5,Int}( 6,11,17, 8,14)
+    F[9 ] = NgonFace{5,Int}(11,12,19, 4,17)
+    F[10] = NgonFace{5,Int}( 1, 2, 8,17, 4)
+    F[11] = NgonFace{5,Int}( 1, 4,19,15,20)
+    F[12] = NgonFace{5,Int}(12,18, 5,15,19)
     
     return GeometryBasics.Mesh(V,F)
 end
@@ -1255,13 +1255,13 @@ function cube(r=1.0)
     V[8 ] = Point{3, Float64}(  s, -s,  s)
         
     # Create faces
-    F = Vector{QuadFace{Int64}}(undef,6)
-    F[1 ] = QuadFace{Int64}(1,2,3,4)
-    F[2 ] = QuadFace{Int64}(8,7,6,5)
-    F[3 ] = QuadFace{Int64}(5,6,2,1)
-    F[4 ] = QuadFace{Int64}(6,7,3,2)    
-    F[5 ] = QuadFace{Int64}(7,8,4,3)    
-    F[6 ] = QuadFace{Int64}(8,5,1,4)    
+    F = Vector{QuadFace{Int}}(undef,6)
+    F[1 ] = QuadFace{Int}(1,2,3,4)
+    F[2 ] = QuadFace{Int}(8,7,6,5)
+    F[3 ] = QuadFace{Int}(5,6,2,1)
+    F[4 ] = QuadFace{Int}(6,7,3,2)    
+    F[5 ] = QuadFace{Int}(7,8,4,3)    
+    F[6 ] = QuadFace{Int}(8,5,1,4)    
 
     return GeometryBasics.Mesh(V,F)
 end
@@ -1291,11 +1291,11 @@ function tetrahedron(r=1.0)
     V[4 ] = Point{3, Float64}(  0.0, -2.0*b,   c)  
 
     # Create faces
-    F = Vector{TriangleFace{Int64}}(undef,4)
-    F[1 ] = TriangleFace{Int64}(1,2,3)
-    F[2 ] = TriangleFace{Int64}(4,2,1)
-    F[3 ] = TriangleFace{Int64}(4,3,2)
-    F[4 ] = TriangleFace{Int64}(4,1,3)
+    F = Vector{TriangleFace{Int}}(undef,4)
+    F[1 ] = TriangleFace{Int}(1,2,3)
+    F[2 ] = TriangleFace{Int}(4,2,1)
+    F[3 ] = TriangleFace{Int}(4,3,2)
+    F[4 ] = TriangleFace{Int}(4,1,3)
     
     return GeometryBasics.Mesh(V,F)
 end
@@ -1360,7 +1360,7 @@ types:
 considered a face
 * `FM::Matrix{TF} where TF<:Integer`, whereby each row is considered a face
 * `Vector{NgonFace{m, OffsetInteger{-1, TF}}} where TF<:Integer`, whereby the 
-special integer type `OffsetInteger{-1, TF}` is converted to `Int64`.  
+special integer type `OffsetInteger{-1, TF}` is converted to `Int`.  
 If the intput is already of the right type this function leaves the input 
 unchanged.
 """
@@ -1397,13 +1397,13 @@ end
 function tofaces(FM::Vector{NgonFace{m, OffsetInteger{-1, TF}}} ) where m where TF <: Integer
     # Loop over face matrix and convert to GeometryBasics vector of Faces (e.g. QuadFace, or TriangleFace)    
     if m == 2 # Edges
-        F = [LineFace{Int64}(f) for f in FM]
+        F = [LineFace{Int}(f) for f in FM]
     elseif m == 3 # Triangles
-        F = [TriangleFace{Int64}(f) for f in FM]
+        F = [TriangleFace{Int}(f) for f in FM]
     elseif m == 4 # Quads
-        F = [QuadFace{Int64}(f) for f in FM]
+        F = [QuadFace{Int}(f) for f in FM]
     else # Other mesh type
-        F = [NgonFace{m,Int64}(f) for f in FM]
+        F = [NgonFace{m,Int}(f) for f in FM]
     end
     return F
 end
@@ -1617,7 +1617,7 @@ method both refines and smoothes the geometry through spline approximation.
 1. [Charles Loop, _Smooth Subdivision Surfaces Based on Triangles_, M.S. Mathematics Thesis, University of Utah. 1987.](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/thesis-10.pdf)
 2. [Jos Stam, Charles Loop, _Quad/Triangle Subdivision_, doi: 10.1111/1467-8659.t01-2-00647](https://doi.org/10.1111/1467-8659.t01-2-00647)
 """
-function subtri(F::Vector{NgonFace{3,TF}},V::Vector{Point{ND,TV}},n::Int64; method = :linear, constrain_boundary=false) where TF<:Integer where ND where TV <: Real
+function subtri(F::Vector{NgonFace{3,TF}},V::Vector{Point{ND,TV}},n::Int; method = :linear, constrain_boundary=false) where TF<:Integer where ND where TV <: Real
     
     if iszero(n)
         return F,V
@@ -1718,8 +1718,8 @@ function subtri(F::Vector{NgonFace{3,TF}},V::Vector{Point{ND,TV}},n::Int64; meth
 end
 
 """
-subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int64; method=:linear) where TF<:Integer where ND where TV <: Real
-subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int64; method=:Catmull_Clark) where TF<:Integer where ND where TV <: Real
+subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int; method=:linear) where TF<:Integer where ND where TV <: Real
+subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int; method=:Catmull_Clark) where TF<:Integer where ND where TV <: Real
 
 Refines quadrangulations through splitting.
 
@@ -1743,7 +1743,7 @@ spline approximation.
 # References
 1. [E. Catmull and J. Clark, _Recursively generated B-spline surfaces on arbitrary topological meshes_, Computer-Aided Design, vol. 10, no. 6, pp. 350-355, Nov. 1978, doi: 10.1016/0010-4485(78)90110-0](https://doi.org/10.1016/0010-4485(78)90110-0).
 """
-function subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int64; method=:linear, constrain_boundary=false) where TF<:Integer where ND where TV <: Real
+function subquad(F::Vector{NgonFace{4,TF}},V::Vector{Point{ND,TV}},n::Int; method=:linear, constrain_boundary=false) where TF<:Integer where ND where TV <: Real
     if iszero(n)
         return F,V
     elseif isone(n)
@@ -1831,7 +1831,7 @@ end
 
 
 """
-    geosphere(n::Int64,r::T) where T <: Real
+    geosphere(n::Int,r::T) where T <: Real
 
 Returns a geodesic sphere triangulation
 
@@ -1844,7 +1844,7 @@ The algorithm starts with a regular icosahedron. Next this icosahedron is refine
 `n` times, while nodes are pushed to a sphere surface with radius `r` at each
 iteration. 
 """
-function geosphere(n::Int64,r::T) where T <: Real
+function geosphere(n::Int,r::T) where T <: Real
     M = platonicsolid(4,r)
     V = coordinates(M)
     F = faces(M)
@@ -1885,7 +1885,7 @@ function hexbox(boxDim,boxEl)
                 [0,1,1]]
                 
     
-    E = Vector{Hex8{Int64}}(undef,numElements) # Allocate elements
+    E = Vector{Hex8{Int}}(undef,numElements) # Allocate elements
 
     @inbounds for q in 1:numElements
         ijk_1 = ind2sub(boxEl,ind1[q])    
@@ -1897,12 +1897,12 @@ function hexbox(boxDim,boxEl)
         ijk_7 = ijk_1 .+ ijk_shift[7]
         ijk_8 = ijk_1 .+ ijk_shift[8]
         
-        E[q] = Hex8{Int64}( sub2ind(boxNod,ijk_1),sub2ind(boxNod,ijk_2),sub2ind(boxNod,ijk_3),sub2ind(boxNod,ijk_4),
+        E[q] = Hex8{Int}( sub2ind(boxNod,ijk_1),sub2ind(boxNod,ijk_2),sub2ind(boxNod,ijk_3),sub2ind(boxNod,ijk_4),
                             sub2ind(boxNod,ijk_5),sub2ind(boxNod,ijk_6),sub2ind(boxNod,ijk_7),sub2ind(boxNod,ijk_8) )
     end
 
     # Create vertices aka nodal coordinates
-    indNodes = collect(Int64,1:numNodes)
+    indNodes = collect(Int,1:numNodes)
     IJK_nodes = ind2sub(boxNod,indNodes)
 
     V = convert(Vector{Point{3, Float64}},IJK_nodes)
@@ -1942,7 +1942,7 @@ function con_face_edge(F,E_uni=nothing,indReverse=nothing)
         E = meshedges(F)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
     end
-    return [Vector{Int64}(a) for a in eachrow(reshape(indReverse,length(F),length(F[1])))] 
+    return [Vector{Int}(a) for a in eachrow(reshape(indReverse,length(F),length(F[1])))] 
 end
 
 
@@ -1967,7 +1967,7 @@ function con_edge_face(F,E_uni=nothing,indReverse=nothing)
     end
     con_F2E = con_face_edge(F,E_uni,indReverse)
     
-    con_E2F = [Vector{Int64}() for _ in 1:length(E_uni)]
+    con_E2F = [Vector{Int}() for _ in 1:length(E_uni)]
     for i_f in eachindex(F)
         for i in con_F2E[i_f]
             push!(con_E2F[i],i_f)
@@ -2006,7 +2006,7 @@ function con_face_face(F,E_uni=nothing,indReverse=nothing,con_E2F=nothing,con_F2
         if isnothing(con_F2E)
             con_F2E = con_face_edge(F,E_uni,indReverse)                 
         end
-        con_F2F = [Vector{Int64}() for _ in 1:length(F)]
+        con_F2F = [Vector{Int}() for _ in 1:length(F)]
         for i_f in eachindex(F)
             for i in reduce(vcat,con_E2F[con_F2E[i_f]])    
                 if i!=i_f     
@@ -2016,7 +2016,7 @@ function con_face_face(F,E_uni=nothing,indReverse=nothing,con_E2F=nothing,con_F2
         end
         return con_F2F
     else # Just one face, so return empty
-        return [Vector{Int64}() ]
+        return [Vector{Int}() ]
     end
 end
 
@@ -2041,7 +2041,7 @@ function con_face_face_v(F,V=nothing,con_V2F=nothing)
         if isnothing(con_V2F) 
             con_V2F = con_vertex_face(F,V)  # VERTEX-FACE connectivity
         end
-        con_F2F = [Vector{Int64}() for _ in 1:length(F)]
+        con_F2F = [Vector{Int}() for _ in 1:length(F)]
         for i_f in eachindex(F)
             for i in unique(reduce(vcat,con_V2F[F[i_f]]))    
                 if i!=i_f     
@@ -2051,7 +2051,7 @@ function con_face_face_v(F,V=nothing,con_V2F=nothing)
         end
         return con_F2F
     else # Just one face, so return empty
-        return [Vector{Int64}() ]
+        return [Vector{Int}() ]
     end
 end
 
@@ -2075,7 +2075,7 @@ function con_vertex_simplex(F,V=nothing)
     else
         n = length(V)
     end
-    con_V2F = [Vector{Int64}() for _ in 1:n]
+    con_V2F = [Vector{Int}() for _ in 1:n]
     for i_f in eachindex(F)
         for i in F[i_f]
             push!(con_V2F[i],i_f)
@@ -2135,7 +2135,7 @@ function con_edge_edge(E_uni,con_V2E=nothing)
     if isnothing(con_V2E)
         con_V2E = con_vertex_edge(E_uni) 
     end    
-    con_E2E = [Vector{Int64}() for _ in 1:length(E_uni)]
+    con_E2E = [Vector{Int}() for _ in 1:length(E_uni)]
     for i_e in eachindex(E_uni)
         for i in reduce(vcat,con_V2E[E_uni[i_e]])    
             if i!=i_e     
@@ -2172,7 +2172,7 @@ function con_vertex_vertex_f(F,V=nothing,con_V2F=nothing)
         con_V2F = con_vertex_face(F,V)
     end
 
-    con_V2V = [Vector{Int64}() for _ in 1:n]
+    con_V2V = [Vector{Int}() for _ in 1:n]
     @inbounds for i_v in 1:n
         if !isempty(con_V2F[i_v])
             for i in unique(reduce(vcat,F[con_V2F[i_v]]))
@@ -2211,7 +2211,7 @@ function con_vertex_vertex(E,V=nothing,con_V2E=nothing)
         con_V2E = con_vertex_edge(E,V)
     end
 
-    con_V2V = [Vector{Int64}() for _ in 1:n]
+    con_V2V = [Vector{Int}() for _ in 1:n]
     @inbounds for i_v in 1:n
         if !isempty(con_V2E[i_v])
             for i in unique(reduce(vcat,E[con_V2E[i_v]]))
@@ -2298,7 +2298,7 @@ function mergevertices(F::Vector{NgonFace{N,TF}},V::Vector{Point{ND,TV}}; roundV
             E = meshedges(F)
             d = [sqrt( sum((V[e[1]] .- V[e[2]]).^2) ) for e in E]
             pointSpacing = mean(d)            
-            numDigitsMerge = 6-round(Int64,log10(pointSpacing))
+            numDigitsMerge = 6-round(Int,log10(pointSpacing))
         end
 
         # Create rounded coordinates to help obtain unique set
@@ -2464,12 +2464,12 @@ function quadplate(plateDim,plateElem)
     #     end
     # end
 
-    F = Vector{QuadFace{Int64}}(undef,prod(plateElem))
+    F = Vector{QuadFace{Int}}(undef,prod(plateElem))
     ij2ind(i,j) = i + ((j-1)*num_x) # function to convert subscript to linear indices    
     c = 1
     for i = 1:plateElem[1]
         for j = 1:plateElem[2]        
-            F[c] = QuadFace{Int64}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i+1,j+1),ij2ind(i,j+1)])
+            F[c] = QuadFace{Int}([ij2ind(i,j),ij2ind(i+1,j),ij2ind(i+1,j+1),ij2ind(i,j+1)])
             c += 1
         end
     end
@@ -2477,7 +2477,7 @@ function quadplate(plateDim,plateElem)
 end
 
 """
-    quadsphere(n::Int64,r::T) where T <: Real
+    quadsphere(n::Int,r::T) where T <: Real
 
 Returns a quadrangulated sphere
 
@@ -2488,7 +2488,7 @@ mesh. The quad mesh is constructed using `subquad` subdivision of a regular cube
 whereby `n` sets the number of splitting iterations to use. Using `n=0` therefore
 returns a cube.
 """
-function quadsphere(n::Int64,r::T) where T <: Real
+function quadsphere(n::Int,r::T) where T <: Real
     M = platonicsolid(2,r)
     F = faces(M)
     V = coordinates(M)
@@ -2547,7 +2547,7 @@ function normalizevector(A::Union{Point{ND,TV},Vec{ND,TV}}) where ND where TV<:R
     return A./norm(A)    
 end
 
-function circlepoints(r::T,n::Int64; dir=:acw) where T <: Real
+function circlepoints(r::T,n::Int; dir=:acw) where T <: Real
     if dir==:acw
         return [Point{3, Float64}(r*cos(t),r*sin(t),0) for t in range(0.0,2.0*π-(2.0*π)/n,n)]
     elseif dir==:cw
@@ -2557,7 +2557,7 @@ function circlepoints(r::T,n::Int64; dir=:acw) where T <: Real
     end
 end
 
-function circlepoints(f::FunctionType,n::Int64; dir=:acw) where {FunctionType <: Function}
+function circlepoints(f::FunctionType,n::Int; dir=:acw) where {FunctionType <: Function}
     if dir==:acw
         return [Point{3, Float64}(f(t)*cos(t),f(t)*sin(t),0) for t in range(0,2*π-(2*π)/n,n)]
     elseif dir==:cw
@@ -2593,7 +2593,7 @@ function loftlinear(V1::Vector{Point{ND,TV}},V2::Vector{Point{ND,TV}};num_steps=
     if isnothing(num_steps)
         d = mean([norm(V1[i]-V2[i]) for i in eachindex(V1)])
         dp = 0.5* (pointspacingmean(V1)+pointspacingmean(V2))
-        num_steps = ceil(Int64,d/dp)        
+        num_steps = ceil(Int,d/dp)        
     end
 
     # Linearly blending points from first to last
@@ -2613,7 +2613,7 @@ function loftpoints2surf(V::Vector{Point{ND,TV}},num_steps; close_loop=true,face
     if !isinteger(nc) || nc<1
         throw(ArgumentError("The length(V)/num_steps should produce an integer >1 but is instead $nc"))
     end
-    nc = Int64(nc)
+    nc = Int(nc)
 
     # Form faces
     if face_type == :tri
@@ -2640,45 +2640,45 @@ function loftpoints2surf(V::Vector{Point{ND,TV}},num_steps; close_loop=true,face
 
     # Build faces
     if face_type == :quad    
-        F = Vector{QuadFace{Int64}}()
+        F = Vector{QuadFace{Int}}()
         @inbounds for i = 1:(nc-1)
             @inbounds for j = 1:(num_steps-1)    
-                push!(F,QuadFace{Int64}([ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1), ij2ind(i,j+1)  ]))
+                push!(F,QuadFace{Int}([ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1), ij2ind(i,j+1)  ]))
             end
         end
 
         # Add faces to close over shape if requested
         if close_loop
             @inbounds for q in 1:(num_steps-1)                
-                push!(F,QuadFace{Int64}([ ij2ind(nc,q), ij2ind(1,q), ij2ind(1,q+1), ij2ind(nc,q+1) ])) 
+                push!(F,QuadFace{Int}([ ij2ind(nc,q), ij2ind(1,q), ij2ind(1,q+1), ij2ind(nc,q+1) ])) 
             end
         end
     elseif face_type == :tri_slash 
-        F = Vector{TriangleFace{Int64}}()
+        F = Vector{TriangleFace{Int}}()
         @inbounds for i = 1:nc-1
             @inbounds for j = 1:num_steps-1    
-                push!(F,TriangleFace{Int64}([     ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1) ])) 
-                push!(F,TriangleFace{Int64}([ ij2ind(i+1,j+1), ij2ind(i,j+1), ij2ind(i,j)     ])) 
+                push!(F,TriangleFace{Int}([     ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1) ])) 
+                push!(F,TriangleFace{Int}([ ij2ind(i+1,j+1), ij2ind(i,j+1), ij2ind(i,j)     ])) 
             end
         end
 
         # Add faces to close over shape if requested
         if close_loop
             @inbounds for q in 1:num_steps-1
-                push!(F,TriangleFace{Int64}([  ij2ind(nc,q),    ij2ind(1,q), ij2ind(1,q+1) ])) 
-                push!(F,TriangleFace{Int64}([ ij2ind(1,q+1), ij2ind(nc,q+1), ij2ind(nc,q)  ])) 
+                push!(F,TriangleFace{Int}([  ij2ind(nc,q),    ij2ind(1,q), ij2ind(1,q+1) ])) 
+                push!(F,TriangleFace{Int}([ ij2ind(1,q+1), ij2ind(nc,q+1), ij2ind(nc,q)  ])) 
             end
         end
     elseif face_type == :tri 
-        F = Vector{TriangleFace{Int64}}()
+        F = Vector{TriangleFace{Int}}()
         @inbounds for i = 1:nc-1
             @inbounds for j = 1:(num_steps-1)    
                 if iseven(j) # Normal slash
-                    push!(F,TriangleFace{Int64}([     ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1) ]))
-                    push!(F,TriangleFace{Int64}([ ij2ind(i+1,j+1), ij2ind(i,j+1), ij2ind(i,j)     ])) 
+                    push!(F,TriangleFace{Int}([     ij2ind(i,j), ij2ind(i+1,j), ij2ind(i+1,j+1) ]))
+                    push!(F,TriangleFace{Int}([ ij2ind(i+1,j+1), ij2ind(i,j+1), ij2ind(i,j)     ])) 
                 else # Other slash 
-                    push!(F,TriangleFace{Int64}([ ij2ind(i+1,j), ij2ind(i+1,j+1), ij2ind(i,j+1) ])) 
-                    push!(F,TriangleFace{Int64}([ ij2ind(i,j+1),     ij2ind(i,j), ij2ind(i+1,j) ]))               
+                    push!(F,TriangleFace{Int}([ ij2ind(i+1,j), ij2ind(i+1,j+1), ij2ind(i,j+1) ])) 
+                    push!(F,TriangleFace{Int}([ ij2ind(i,j+1),     ij2ind(i,j), ij2ind(i+1,j) ]))               
                 end
             end
         end
@@ -2687,11 +2687,11 @@ function loftpoints2surf(V::Vector{Point{ND,TV}},num_steps; close_loop=true,face
         if close_loop
             @inbounds for q in 1:(num_steps-1)
                 if iseven(q) 
-                    push!(F,TriangleFace{Int64}([ ij2ind(1,q+1), ij2ind(nc,q+1), ij2ind(nc,q)  ])) 
-                    push!(F,TriangleFace{Int64}([  ij2ind(nc,q),    ij2ind(1,q), ij2ind(1,q+1) ])) 
+                    push!(F,TriangleFace{Int}([ ij2ind(1,q+1), ij2ind(nc,q+1), ij2ind(nc,q)  ])) 
+                    push!(F,TriangleFace{Int}([  ij2ind(nc,q),    ij2ind(1,q), ij2ind(1,q+1) ])) 
                 else
-                    push!(F,TriangleFace{Int64}([    ij2ind(1,q), ij2ind(1,q+1), ij2ind(nc,q+1) ]))
-                    push!(F,TriangleFace{Int64}([ ij2ind(nc,q+1),  ij2ind(nc,q), ij2ind(1,q)    ]))   
+                    push!(F,TriangleFace{Int}([    ij2ind(1,q), ij2ind(1,q+1), ij2ind(nc,q+1) ]))
+                    push!(F,TriangleFace{Int}([ ij2ind(nc,q+1),  ij2ind(nc,q), ij2ind(1,q)    ]))   
                 end
             end
         end
@@ -2706,7 +2706,7 @@ end
 
 
 function dirplot(ax,V::Vector{Point{ND,TV1}},U::Union{Vector{Point{ND,TV2}},Vector{Vec{ND,TV2}}}; color=:black,linewidth=3,scaleval=1.0,style=:from) where ND where TV1 <: Real where TV2 <: Real
-    E = [LineFace{Int64}(i,i+length(V)) for i in 1:length(V)]
+    E = [LineFace{Int}(i,i+length(V)) for i in 1:length(V)]
 
     if style==:from        
         P = deepcopy(V)
@@ -2803,11 +2803,11 @@ function remove_unused_vertices(F,V::Vector{Point{ND,TV}})::Tuple where ND where
     if isempty(F) # If the face set is empty, return all emtpy outputs
         Fc = F
         Vc = Vector{Point{ND,TV}}(undef,0)
-        indFix = Vector{Int64}(undef,0)
+        indFix = Vector{Int}(undef,0)
     else # Faces not empty to check which indices are used and shorten V if needed        
         indUsed = elements2indices(F) # Indices used
         Vc = V[indUsed] # Remove unused points    
-        indFix = zeros(Int64,length(V))
+        indFix = zeros(Int,length(V))
         indFix[indUsed] .= 1:length(indUsed)
         Fc = [(eltype(F))(indFix[f]) for f in F] # Fix indices in F         
     end
@@ -2829,9 +2829,9 @@ function trisurfslice(F::Vector{TriangleFace{TF}},V::Vector{Point{ND,TV}},n = Ve
     LV = d.<0.0
     
     Fn =  Vector{TriangleFace{TF}}()
-    Cn =  Vector{Int64}()
+    Cn =  Vector{Int}()
     Vn = deepcopy(V)
-    D = Dict{Vector{Int64},Int64}() # For pointing from edge to intersection point index
+    D = Dict{Vector{Int},Int}() # For pointing from edge to intersection point index
     for f in F
         lf = LV[f]
         
@@ -2909,14 +2909,14 @@ function trisurfslice(F::Vector{TriangleFace{TF}},V::Vector{Point{ND,TV}},n = Ve
     return Fn,Vn,Cn
 end
 
-function count_edge_face(F,E_uni=nothing,indReverse=nothing)::Vector{Int64}
+function count_edge_face(F,E_uni=nothing,indReverse=nothing)::Vector{Int}
     if isnothing(E_uni) || isnothing(indReverse)
         E = meshedges(F)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
     end
     con_F2E = con_face_edge(F,E_uni,indReverse)
     
-    C = zeros(Int64,length(E_uni))
+    C = zeros(Int,length(E_uni))
     for i_f in eachindex(F)
         for i in con_F2E[i_f]
             C[i]+=1
@@ -3032,7 +3032,7 @@ end
 
 """
     pointspacingmean(V::Vector{Point3{Float64}})
-    pointspacingmean(F::Array{NgonFace{N, Int64}, 1},V::Vector{Point3{Float64}}) where N
+    pointspacingmean(F::Array{NgonFace{N, Int}, 1},V::Vector{Point3{Float64}}) where N
 
 The `pointspacingmean` function computes the mean spacing between points. The 
 input can be just the coordinate set `V`, a vector of Point3 
@@ -3053,7 +3053,7 @@ function pointspacingmean(V::Vector{Point{ND,TV}}) where ND where TV <: Real
 end
 
 function pointspacingmean(F::Vector{NgonFace{N,TF}},V::Vector{Point{ND,TV}}) where N where TF<:Integer where ND where TV<:Real
-    if isa(F,Vector{LineFace{Int64}})
+    if isa(F,Vector{LineFace{Int}})
         E = F
     else
         E = meshedges(F; unique_only=true)
@@ -3101,9 +3101,9 @@ function extrudecurve(V1::Vector{Point{ND,TV}}; extent=1.0, direction=:positive,
 
     # Derive num_steps from curve point spacing if missing    
     if isnothing(num_steps)
-        num_steps = ceil(Int64,extent/pointspacingmean(V1))
+        num_steps = ceil(Int,extent/pointspacingmean(V1))
         if face_type==:tri
-            num_steps = num_steps + Int64(iseven(num_steps)) # Force uneven
+            num_steps = num_steps + Int(iseven(num_steps)) # Force uneven
         end
     end
 
@@ -3157,13 +3157,13 @@ function meshgroup(F; con_type = :v)
         i = 1
         c = 1
         C[i] = c 
-        seen = Set{Int64}(1)
+        seen = Set{Int}(1)
         while length(seen)<length(F)
             np = length(seen)
             con_f2f = con_F2F[i]
             if !isempty(con_f2f)
                 ind_F = reduce(vcat,con_f2f)
-                i = Vector{Int64}()
+                i = Vector{Int}()
                 for ii in  ind_F
                     if !in(ii,seen)
                         push!(seen,ii)
@@ -3195,7 +3195,7 @@ function distmarch(F,V::Vector{Point{ND,TV}},indStart; d=nothing, dd=nothing, di
 
     # Compute "Laplacian umbrella" distances
     if isnothing(dd)
-        dd = Dict{Vector{Int64},Float64}()  
+        dd = Dict{Vector{Int},Float64}()  
         for i in eachindex(V)
             for ii in con_V2V[i]
                 k = sort([i,ii])
@@ -3269,15 +3269,15 @@ end
 
 
 """
-    ray_triangle_intersect(F::Vector{TriangleFace{Int64}},V,ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64))
-    ray_triangle_intersect(f::TriangleFace{Int64},V,ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64))
+    ray_triangle_intersect(F::Vector{TriangleFace{Int}},V,ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64))
+    ray_triangle_intersect(f::TriangleFace{Int},V,ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64))
 
 # Description 
 This function can compute triangle-ray or triangle-line intersections through 
 the use of the "Möller-Trumbore triangle-ray intersection algorithm" [1]. The 
 required inputs are as follows: 
 
-`F` an single face or a vector of faces, e.g. `Vector{TriangleFace{Int64}}`
+`F` an single face or a vector of faces, e.g. `Vector{TriangleFace{Int}}`
 `V` The triangle vertices as a vector of points, i.e. `Vector{Point{3, Float64}}`
 `ray_vector` The ray vector which can be `Vector{Point{3, Float64}}` or `Vec3{Float64}`
 
@@ -3294,7 +3294,7 @@ When `triSide=0` both inward and outward intersections are considered.
 """
 function ray_triangle_intersect(F::Vector{TriangleFace{TF}},V::Vector{Point{ND,TV}},ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64)) where TF <: Integer where ND where TV<:Real
     P = Vector{Point{ND,TV}}()
-    indIntersect = Vector{Int64}()
+    indIntersect = Vector{Int}()
     for qf in eachindex(F)
         p = ray_triangle_intersect(F[qf],V,ray_origin,ray_vector; rayType = rayType, triSide = triSide, tolEps = tolEps)        
         if !any(isnan.(p))
@@ -3305,7 +3305,7 @@ function ray_triangle_intersect(F::Vector{TriangleFace{TF}},V::Vector{Point{ND,T
     return P,indIntersect
 end
 
-function ray_triangle_intersect(f::TriangleFace{Int64},V::Vector{Point{ND,TV}},ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64)) where ND where TV<:Real
+function ray_triangle_intersect(f::TriangleFace{Int},V::Vector{Point{ND,TV}},ray_origin,ray_vector; rayType = :ray, triSide = 1, tolEps = eps(Float64)) where ND where TV<:Real
 
     # Edge vectors
     P1 = V[f[1]] # First corner point
@@ -3343,7 +3343,7 @@ function ray_triangle_intersect(f::TriangleFace{Int64},V::Vector{Point{ND,TV}},r
 end
 
 """
-    mesh_curvature_polynomial(F::Vector{TriangleFace{Int64}},V::Vector{Point3{Float64}})
+    mesh_curvature_polynomial(F::Vector{TriangleFace{Int}},V::Vector{Point3{Float64}})
     mesh_curvature_polynomial(M::GeometryBasics.Mesh)
 
 # Description
@@ -3419,7 +3419,7 @@ function mesh_curvature_polynomial(M::GeometryBasics.Mesh)
 end
 
 """
-    separate_vertices(F::Array{NgonFace{N, Int64}, 1},V::Array{Point{M, T}, 1}) where N where M where T<:Real
+    separate_vertices(F::Array{NgonFace{N, Int}, 1},V::Array{Point{M, T}, 1}) where N where M where T<:Real
     separate_vertices(M::GeometryBasics.Mesh)
 
 This function takes the input mesh defined by the faces `F` and vertices `V` and
@@ -3466,7 +3466,7 @@ end
 
 
 """
-    evenly_sample(V::Vector{Point{ND,TV}}, n::Int64; rtol = 1e-8, niter = 1) where ND where TV<:Real
+    evenly_sample(V::Vector{Point{ND,TV}}, n::Int; rtol = 1e-8, niter = 1) where ND where TV<:Real
 
 Evenly samples curves. 
 
@@ -3482,7 +3482,7 @@ curvature exists for the B-spline between two adjacent data points then the
 spacing between points in the output may be non-uniform (despite the allong 
 B-spline distance being uniform). 
 """
-function evenly_sample(V::Vector{Point{ND,TV}}, n::Int64; rtol = 1e-8, niter = 1,spline_order=4, close_loop=false) where ND where TV<:Real
+function evenly_sample(V::Vector{Point{ND,TV}}, n::Int; rtol = 1e-8, niter = 1,spline_order=4, close_loop=false) where ND where TV<:Real
     LL = curve_length(V) # Initialise as along curve (multi-linear) distance
 
     if close_loop == true
@@ -3530,7 +3530,7 @@ function evenly_space(V::Vector{Point{ND,TV}}, pointSpacing=nothing; rtol = 1e-8
     if isnothing(pointSpacing)
         pointSpacing = pointspacingmean(V)
     end
-    n = ceil(Int64,maximum(curve_length(V; close_loop=close_loop))/pointSpacing)
+    n = ceil(Int,maximum(curve_length(V; close_loop=close_loop))/pointSpacing)
     Vn,_ = evenly_sample(V,n; rtol=rtol, niter=niter, close_loop=close_loop)
     return Vn
 end
@@ -3546,7 +3546,7 @@ This function inverts the faces in `F`, such that the face normal will be
 flipped, by reversing the node order for each face. 
 """
 function invert_faces(F::Vector{NgonFace{N, TF}}) where N where TF<:Integer     
-    return map(f-> reverse(f),F) # [NgonFace{N, Int64}(reverse(f)) for f in F]    
+    return map(f-> reverse(f),F) # [NgonFace{N, Int}(reverse(f)) for f in F]    
 end
 
 
@@ -3715,7 +3715,7 @@ function revolvecurve(Vc::Vector{Point{ND,TV}}; extent = 2.0*pi, direction=:posi
                 rMax = max(rMax,rNow)
             end
         end
-        num_steps = ceil(Int64,(rMax*extent)/pointspacingmean(Vc))        
+        num_steps = ceil(Int,(rMax*extent)/pointspacingmean(Vc))        
     end
     
     # Set up angle range
@@ -3741,7 +3741,7 @@ end
 
 
 """
-    batman(n::Int64)
+    batman(n::Int)
 # Description
 The `batman` function creates points on the curve for the Batman logo. The curve
 is useful for testing surface meshing algorithms since it contains sharp 
@@ -3760,7 +3760,7 @@ direction is anti-clockwise.
 # References 
 1. https://www.desmos.com/calculator/ajnzwedvql
 """
-function batman(n::Int64; symmetric = false, dir=:acw)
+function batman(n::Int; symmetric = false, dir=:acw)
     tt = range(8,0.0,n)
 
     x = [( 0.3*t + 0.2*abs(t-1.0) + 2.2*abs(t-2.0) - 2.7*abs(t-3.0) -3.0*abs(t-5.0) + 3*abs(t-7.0) 
@@ -3778,9 +3778,9 @@ function batman(n::Int64; symmetric = false, dir=:acw)
 
     if symmetric == true    
         if iseven(n)
-            m = round(Int64,n/2+1)
+            m = round(Int,n/2+1)
         else
-            m = ceil(Int64,n/2)+1 
+            m = ceil(Int,n/2)+1 
         end
         V,_ = evenly_sample([Point{3, Float64}(x[i]/22,y[i]/22,0.0) for i in eachindex(x)],m)
         V2 = [Point{3, Float64}(-V[i][1],V[i][2],0.0) for i in length(V)-1:-1:2]
@@ -3813,7 +3813,7 @@ function tridisc(r=1.0,n=0)
     # Create a triangulated hexagon
     V = circlepoints(r,6)
     push!(V,Point{3,Float64}(0.0,0.0,0.0))
-    F = [TriangleFace{Int64}(1,2,7), TriangleFace{Int64}(2,3,7), TriangleFace{Int64}(3,4,7), TriangleFace{Int64}(4,5,7), TriangleFace{Int64}(5,6,7), TriangleFace{Int64}(6,1,7)]
+    F = [TriangleFace{Int}(1,2,7), TriangleFace{Int}(2,3,7), TriangleFace{Int}(3,4,7), TriangleFace{Int}(4,5,7), TriangleFace{Int}(5,6,7), TriangleFace{Int}(6,1,7)]
 
     # Refine mesh n times
     if n>0
@@ -3853,7 +3853,7 @@ defining holes in this region.
 """
 function regiontrimesh(VT,R,P)
     V = Vector{Point{3,Float64}}() # eltype(VT)()
-    F = Vector{TriangleFace{Int64}}()
+    F = Vector{TriangleFace{Int}}()
     C = Vector{Float64}()
     
     for q in eachindex(R)        
@@ -3863,7 +3863,7 @@ function regiontrimesh(VT,R,P)
         numCurvePoints = length(Vn) # Number of points in the current curve set
 
         # Creating constraints
-        constrained_segments = Vector{Vector{Vector{Int64}}}()
+        constrained_segments = Vector{Vector{Vector{Int}}}()
         n = 1        
         for i in eachindex(r)
             m = length(VT[r[i]])            
@@ -3884,7 +3884,7 @@ function regiontrimesh(VT,R,P)
         # Initial triangulation 
         constrained_segments_ori = deepcopy(constrained_segments) # Clone since triangulate can add new constraint points
         TRn = triangulate(Vn; boundary_nodes=constrained_segments, delete_ghosts=true)
-        Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
+        Fn = [TriangleFace{Int}(tr) for tr in TRn.triangles] 
 
         # Check if new boundary points were introduced and remove if needed 
         Eb = boundaryedges(Fn)
@@ -3894,12 +3894,12 @@ function regiontrimesh(VT,R,P)
             logicKeep = fill(true,length(Vn))
             logicKeep[indRemove] .= false
             indKeep = findall(logicKeep)
-            indFix = zeros(Int64,length(Vn))
+            indFix = zeros(Int,length(Vn))
             indFix[indKeep] = 1:length(indKeep)
             Vn = Vn[indKeep]
             constrained_segments = [[indFix[c[1]]] for c in constrained_segments_ori] # Fix indices after point removal                
             TRn = triangulate(Vn; boundary_nodes=constrained_segments,delete_ghosts=true)
-            Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
+            Fn = [TriangleFace{Int}(tr) for tr in TRn.triangles] 
             Vn = TRn.points
         end
 
@@ -3920,7 +3920,7 @@ function regiontrimesh(VT,R,P)
         logicKeep = fill(true,length(Vn))
         logicKeep[indRemove] .= false
         indKeep = findall(logicKeep)
-        indFix = zeros(Int64,length(Vn))
+        indFix = zeros(Int,length(Vn))
         indFix[indKeep] = 1:length(indKeep)
 
         Vn = Vn[indKeep] # Remove points 
@@ -3928,7 +3928,7 @@ function regiontrimesh(VT,R,P)
 
         # Redo triangulation after points have been removed
         TRn = triangulate(Vn; boundary_nodes=constrained_segments,delete_ghosts=true)
-        Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
+        Fn = [TriangleFace{Int}(tr) for tr in TRn.triangles] 
         Vn = TRn.points
 
         Fn,Vn,indFix = remove_unused_vertices(Fn,Vn)
@@ -4018,9 +4018,9 @@ function dualclad(F::Vector{NgonFace{N, TF}},V::Vector{Point{ND,TV}},s; connecti
     if connectivity == :face 
         # Compute dict to find partner edges, unique edges as well as reverse indices for unique mapping
         E_sort = sort.(E) 
-        d = Dict{eltype(E),Vector{Int64}}() # Use dict to keep track of used values    
+        d = Dict{eltype(E),Vector{Int}}() # Use dict to keep track of used values    
         Eu = Vector{eltype(E)}()
-        indReverse = Vector{Int64}(undef,length(E)) 
+        indReverse = Vector{Int}(undef,length(E)) 
         j=0
         for (i,e) in enumerate(E_sort)          
             if !haskey(d, e)    
@@ -4039,7 +4039,7 @@ function dualclad(F::Vector{NgonFace{N, TF}},V::Vector{Point{ND,TV}},s; connecti
         indBoundary = findall(isone.(count_E2F))
         Eb = Eu[indBoundary]
 
-        indX = zeros(Int64,length(Eu))
+        indX = zeros(Int,length(Eu))
         indX[indBoundary]=1:length(indBoundary)
         indX_E = indX[indReverse]
 
@@ -4050,7 +4050,7 @@ function dualclad(F::Vector{NgonFace{N, TF}},V::Vector{Point{ND,TV}},s; connecti
             append!(Vs,Vbs) # Append boundary edge points 
         end
 
-        Fq = Vector{QuadFace{Int64}}(undef,length(Eu))
+        Fq = Vector{QuadFace{Int}}(undef,length(Eu))
         for (i,e) in enumerate(Eu)
             ii = d[sort(e)]
             if length(ii)==2
@@ -4067,7 +4067,7 @@ function dualclad(F::Vector{NgonFace{N, TF}},V::Vector{Point{ND,TV}},s; connecti
         Es = [e.+length(Vs) for e in Es]
         append!(Vs,V_Es) # Append boundary edge points 
         
-        Fq = Vector{QuadFace{Int64}}(undef,length(E_Fs))
+        Fq = Vector{QuadFace{Int}}(undef,length(E_Fs))
         for i in eachindex(E_Fs)
             ii = indReverse[i]
             if E[i][1] == Eu[ii][1] # A first occurance edge, order matches
@@ -4204,7 +4204,7 @@ function element2faces(E::Vector{Element{N,T}}) where N where T
 end
 
 """
-    subhex(E::Vector{Hex8{T}},V::Vector{Point{ND,TV}},n::Int64; direction=0) where T<:Integer where ND where TV<:Real
+    subhex(E::Vector{Hex8{T}},V::Vector{Point{ND,TV}},n::Int; direction=0) where T<:Integer where ND where TV<:Real
 
 Split hexahedral elements
 
@@ -4218,7 +4218,7 @@ on node order used. For a hexahedron where by nodes 1:4 are for the bottom, and
 nodes 5:8 are for the top of the element then the directions 1, 2, and 3 correspond 
 to the x-, y-, and z-direction respectively.  
 """
-function subhex(E::Vector{Hex8{T}},V::Vector{Point{ND,TV}},n::Int64; direction=0) where T<:Integer where ND where TV<:Real
+function subhex(E::Vector{Hex8{T}},V::Vector{Point{ND,TV}},n::Int; direction=0) where T<:Integer where ND where TV<:Real
     if iszero(n)
         return E,V
     elseif isone(n)
@@ -4379,7 +4379,7 @@ function subhex(E::Vector{Hex8{T}},V::Vector{Point{ND,TV}},n::Int64; direction=0
 end
 
 function rhombicdodecahedron(r = 1.0)
-    F = Vector{QuadFace{Int64}}(undef,12)
+    F = Vector{QuadFace{Int}}(undef,12)
     F[ 1] = [ 1, 10,  5,  9]
     F[ 2] = [ 2, 11,  6, 10]
     F[ 3] = [ 3, 12,  7, 11]
@@ -4430,29 +4430,29 @@ function tri2quad(F,V; method=:split)
         Vq = [V; Vf; Ve] # Append point sets
 
         # Create quadrilateral faces 
-        Fq = Vector{QuadFace{Int64}}(undef,length(F)*3)
+        Fq = Vector{QuadFace{Int}}(undef,length(F)*3)
         inv_E .+= length(V)+length(F) # Offset 
         nf = length(F)
         for (i,f) in enumerate(F)
             i_f = 1 + (i-1)*3 # Index of first face
             i_vf = i + length(V) # Index of mid face points
-            Fq[i_f  ] = QuadFace{Int64}(f[1], inv_E[i     ], i_vf, inv_E[i+2*nf] )
-            Fq[i_f+1] = QuadFace{Int64}(f[2], inv_E[i+  nf], i_vf, inv_E[i     ] )
-            Fq[i_f+2] = QuadFace{Int64}(f[3], inv_E[i+2*nf], i_vf, inv_E[i+  nf] )
+            Fq[i_f  ] = QuadFace{Int}(f[1], inv_E[i     ], i_vf, inv_E[i+2*nf] )
+            Fq[i_f+1] = QuadFace{Int}(f[2], inv_E[i+  nf], i_vf, inv_E[i     ] )
+            Fq[i_f+2] = QuadFace{Int}(f[3], inv_E[i+2*nf], i_vf, inv_E[i+  nf] )
         end
     elseif method == :rhombic
         con_E2F = con_edge_face(F,Eu,inv_E)
         nv = length(V)
-        Fq = Vector{QuadFace{Int64}}()
-        seen = Dict{Int64,LineFace{Int64}}()  
+        Fq = Vector{QuadFace{Int}}()
+        seen = Dict{Int,LineFace{Int}}()  
         for (i,e) in enumerate(Eu)  
             ind_F = con_E2F[i]
             f1 = F[ind_F[1]]
             if length(ind_F) == 2 # Edge touches two faces 
                 if e == f1[1:2] || e == f1[2:3] || e == f1[[3,1]] 
-                    push!(Fq, QuadFace{Int64}(e[1],ind_F[2]+nv,e[2],ind_F[1]+nv) )
+                    push!(Fq, QuadFace{Int}(e[1],ind_F[2]+nv,e[2],ind_F[1]+nv) )
                 else
-                    push!(Fq, QuadFace{Int64}(e[1],ind_F[1]+nv,e[2],ind_F[2]+nv) )
+                    push!(Fq, QuadFace{Int}(e[1],ind_F[1]+nv,e[2],ind_F[2]+nv) )
                 end 
             else # Edge touches one face
                 i_f = ind_F[1] 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,22 +50,22 @@ end
 
 @testset "elements2indices" verbose = true begin
     @testset "Tri. faces" begin
-        F = Vector{TriangleFace{Int64}}(undef, 3)
-        F[1] = TriangleFace{Int64}(9, 4, 1)
-        F[2] = TriangleFace{Int64}(1, 5, 9)
-        F[3] = TriangleFace{Int64}(1, 8, 5)
+        F = Vector{TriangleFace{Int}}(undef, 3)
+        F[1] = TriangleFace{Int}(9, 4, 1)
+        F[2] = TriangleFace{Int}(1, 5, 9)
+        F[3] = TriangleFace{Int}(1, 8, 5)
         result = elements2indices(F)
         @test sort(result) == [1, 4, 5, 8, 9]
     end
 
     @testset "Quad. faces" begin
-        F = Vector{QuadFace{Int64}}(undef, 6)
-        F[1] = QuadFace{Int64}(1, 2, 3, 4)
-        F[2] = QuadFace{Int64}(8, 7, 6, 5)
-        F[3] = QuadFace{Int64}(5, 6, 2, 1)
-        F[4] = QuadFace{Int64}(6, 7, 3, 2)
-        F[5] = QuadFace{Int64}(7, 8, 4, 3)
-        F[6] = QuadFace{Int64}(8, 5, 1, 4)
+        F = Vector{QuadFace{Int}}(undef, 6)
+        F[1] = QuadFace{Int}(1, 2, 3, 4)
+        F[2] = QuadFace{Int}(8, 7, 6, 5)
+        F[3] = QuadFace{Int}(5, 6, 2, 1)
+        F[4] = QuadFace{Int}(6, 7, 3, 2)
+        F[5] = QuadFace{Int}(7, 8, 4, 3)
+        F[6] = QuadFace{Int}(8, 5, 1, 4)
         result = elements2indices(F)
         @test sort(result) == [1, 2, 3, 4, 5, 6, 7, 8]
     end
@@ -161,7 +161,7 @@ end
         ySpan = [-2,2]
         pointSpacing = 0.5
         V = gridpoints_equilateral(xSpan,ySpan,pointSpacing; return_faces = false, rectangular=false)
-        ind = round.(Int64,range(1,length(V),10))
+        ind = round.(Int,range(1,length(V),10))
         
         @test isa(V,Vector{Point{3,Float64}})
         @test isapprox(V[ind],Point3{Float64}[[-3.125, -2.0, 0.0], 
@@ -180,7 +180,7 @@ end
         ySpan = (-2,2)
         pointSpacing = 1
         V = gridpoints_equilateral(xSpan,ySpan,pointSpacing; return_faces = false, rectangular=true)
-        ind = round.(Int64,range(1,length(V),10))
+        ind = round.(Int,range(1,length(V),10))
 
         @test isa(V,Vector{Point{3,Float64}})
         @test isapprox(V[ind],Point3{Float64}[[-3.0, -2.0, 0.0], [0.75, -2.0, 0.0], 
@@ -200,11 +200,11 @@ end
         ySpan = (-2,2)
         pointSpacing = 1
         F,V = gridpoints_equilateral(xSpan,ySpan,pointSpacing; return_faces = true, rectangular=true)
-        ind = round.(Int64,range(1,length(V),10))
-        indF = round.(Int64,range(1,length(F),10))
+        ind = round.(Int,range(1,length(V),10))
+        indF = round.(Int,range(1,length(F),10))
 
-        @test isa(F,Vector{TriangleFace{Int64}})
-        @test F[indF] == TriangleFace{Int64}[TriangleFace(1, 2, 8), 
+        @test isa(F,Vector{TriangleFace{Int}})
+        @test F[indF] == TriangleFace{Int}[TriangleFace(1, 2, 8), 
         TriangleFace(16, 23, 22), TriangleFace(9, 10, 17), TriangleFace(3, 4, 10), 
         TriangleFace(18, 25, 24), TriangleFace(11, 12, 19), TriangleFace(33, 32, 25), 
         TriangleFace(20, 27, 26), TriangleFace(13, 14, 21), TriangleFace(35, 34, 27)]
@@ -612,33 +612,33 @@ end
 
     @testset "vector edges or faces" begin 
         # Vector of integers (pre-sorted)
-        A = LineFace{Int64}[[3,1],[2,0],[3,1],[4,0],[2,0],[5,0],[6,0]]
+        A = LineFace{Int}[[3,1],[2,0],[3,1],[4,0],[2,0],[5,0],[6,0]]
         B_true = Bool[0, 0, 0, 1, 0, 1, 1]
         @test occursonce(A) == B_true
 
         # Vector of vectors (not sorted)
-        A = LineFace{Int64}[[3,1],[2,0],[1,3],[4,0],[2,0],[5,0],[6,0]]
+        A = LineFace{Int}[[3,1],[2,0],[1,3],[4,0],[2,0],[5,0],[6,0]]
         B_true = Bool[1, 0, 1, 1, 0, 1, 1]
         @test occursonce(A) == B_true
        
         # Vector of vectors pre-sorting used
-        A = LineFace{Int64}[[3,1],[2,0],[1,3],[4,0],[2,0],[5,0],[6,0]]
+        A = LineFace{Int}[[3,1],[2,0],[1,3],[4,0],[2,0],[5,0],[6,0]]
         B_true = Bool[0, 0, 0, 1, 0, 1, 1]
         @test occursonce(A; sort_entries=true) == B_true
 
 
         # Vector of integers (pre-sorted)
-        A = TriangleFace{Int64}[[3,1,2],[2,1,2],[3,1,2],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
+        A = TriangleFace{Int}[[3,1,2],[2,1,2],[3,1,2],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
         B_true = Bool[0, 0, 0, 1, 0, 1, 1]
         @test occursonce(A) == B_true
 
         # Vector of vectors (not sorted)
-        A = TriangleFace{Int64}[[3,1,2],[2,1,2],[3,2,1],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
+        A = TriangleFace{Int}[[3,1,2],[2,1,2],[3,2,1],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
         B_true = Bool[1, 0, 1, 1, 0, 1, 1]
         @test occursonce(A) == B_true
         
         # Vector of vectors pre-sorting used
-        A = TriangleFace{Int64}[[3,1,2],[2,1,2],[3,2,1],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
+        A = TriangleFace{Int}[[3,1,2],[2,1,2],[3,2,1],[4,1,2],[2,1,2],[5,1,2],[6,1,2]]
         B_true = Bool[0, 0, 0, 1, 0, 1, 1]
         @test occursonce(A; sort_entries=true) == B_true        
     end
@@ -675,7 +675,7 @@ end
 
 @testset "unique_simplices" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]       
+        F = [TriangleFace{Int}(1, 2, 3)]       
         V = [Point3{Float64}(rand(3)) for _ in 1:3]
         F_uni, ind1, ind2 = unique_simplices(F)
         @test F_uni == F
@@ -684,7 +684,7 @@ end
     end
 
     @testset "Set of two triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 2, 3)]   
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 2, 3)]   
         V = [Point3{Float64}(rand(3)) for _ in 1:3]    
         F_uni, ind1, ind2 = unique_simplices(F)
         @test F_uni == [F[1]]
@@ -714,7 +714,7 @@ end
         A = rand(30)
         IJK_A = ind2sub(size(A),ind)
         @test all([A[ind[i]] == A[IJK_A[i][1]] for i in eachindex(ind)])
-        @test isempty(ind2sub(size(A),Int64[])) # Check if empty is returned
+        @test isempty(ind2sub(size(A),Int[])) # Check if empty is returned
     end
 
     @testset "2D i.e. 2D Matrix" begin
@@ -833,33 +833,33 @@ end
 
 @testset "meshedges" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]       
+        F = [TriangleFace{Int}(1, 2, 3)]       
         E = meshedges(F)
-        @test E == LineFace{Int64}[[1, 2], [2, 3], [3, 1]]
+        @test E == LineFace{Int}[[1, 2], [2, 3], [3, 1]]
     end
 
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]       
+        F = [QuadFace{Int}(1, 2, 3, 4)]       
         E = meshedges(F)
-        @test E == LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 1]]
+        @test E == LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 1]]
     end
 
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         E = meshedges(F)
-        @test E == LineFace{Int64}[[1, 2], [1, 4], [2, 3], [4, 3], [3, 1], [3, 1]]
+        @test E == LineFace{Int}[[1, 2], [1, 4], [2, 3], [4, 3], [3, 1], [3, 1]]
     end
 
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         E = meshedges(F)
-        @test E == LineFace{Int64}[[1, 2], [6, 5], [2, 3], [5, 4], [3, 4], [4, 3], [4, 1], [3, 6]]
+        @test E == LineFace{Int}[[1, 2], [6, 5], [2, 3], [5, 4], [3, 4], [4, 3], [4, 1], [3, 6]]
     end
 
     @testset "Mesh" begin
         M = cube(1.0)
         E = meshedges(M,unique_only=true)
-        @test E == LineFace{Int64}[[1, 2], [7, 8], [5, 6], [6, 7], [5, 8], [2, 3], 
+        @test E == LineFace{Int}[[1, 2], [7, 8], [5, 6], [6, 7], [5, 8], [2, 3], 
         [2, 6], [3, 7], [4, 8], [1, 5], [3, 4], [1, 4]]
     end
 end
@@ -874,7 +874,7 @@ end
     M = icosahedron(r)
     F = faces(M)
     V = coordinates(M)
-    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int64,Point3{Float64},TriangleFace{Int64}}}
+    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int,Point3{Float64},TriangleFace{Int}}}
     @test length(F) == 20
     @test isapprox(V[1], [0.0, -s, -t], atol=eps_level)
 end
@@ -887,7 +887,7 @@ end
     M = octahedron(1.0) 
     F = faces(M)
     V = coordinates(M)
-    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int64,Point3{Float64},TriangleFace{Int64}}}
+    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int,Point3{Float64},TriangleFace{Int}}}
     @test length(F) == 8
     @test isapprox(V[1], [-s,  -s, 0.0], atol=eps_level)
 end
@@ -903,7 +903,7 @@ end
     M = dodecahedron(r)
     F = faces(M)
     V = coordinates(M)
-    @test M isa GeometryBasics.Mesh{3, Float64, GeometryBasics.Ngon{3, Float64, 5, Point3{Float64}}, SimpleFaceView{3, Float64, 5, Int64, Point3{Float64}, NgonFace{5, Int64}}}
+    @test M isa GeometryBasics.Mesh{3, Float64, GeometryBasics.Ngon{3, Float64, 5, Point3{Float64}}, SimpleFaceView{3, Float64, 5, Int, Point3{Float64}, NgonFace{5, Int}}}
     @test length(F) == 12
     @test isapprox(V[1], [s,s,s], atol=eps_level)
 end
@@ -916,7 +916,7 @@ end
     M = cube(1.0) 
     F = faces(M)
     V = coordinates(M)
-    @test M isa GeometryBasics.Mesh{3, Float64, GeometryBasics.Ngon{3, Float64, 4, Point3{Float64}}, SimpleFaceView{3, Float64, 4, Int64, Point3{Float64}, QuadFace{Int64}}}
+    @test M isa GeometryBasics.Mesh{3, Float64, GeometryBasics.Ngon{3, Float64, 4, Point3{Float64}}, SimpleFaceView{3, Float64, 4, Int, Point3{Float64}, QuadFace{Int}}}
     @test length(F) == 6
     @test isapprox(V[1], [-s,  -s, -s], atol=eps_level)
 end
@@ -931,7 +931,7 @@ end
     M = tetrahedron(1.0) 
     F = faces(M)
     V = coordinates(M)
-    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int64,Point3{Float64},TriangleFace{Int64}}}
+    @test M isa GeometryBasics.Mesh{3,Float64,GeometryBasics.Ngon{3,Float64,3,Point3{Float64}},SimpleFaceView{3,Float64,3,Int,Point3{Float64},TriangleFace{Int}}}
     @test length(F) == 4
     @test isapprox(V[1], [-a,  b, c], atol=eps_level)
 end
@@ -980,49 +980,49 @@ end
     @testset "Matrix input" verbose = true begin        
         Fem_G = tofaces([Fem[1,:]])
         @testset "1 LineFace" begin        
-            @test isa(Fem_G,Vector{GeometryBasics.LineFace{Int64}})
+            @test isa(Fem_G,Vector{GeometryBasics.LineFace{Int}})
             @test length(Fem_G) == 1
         end
 
         Ftm_G = tofaces([Ftm[1,:]])
         @testset "1 TriangleFace" begin        
-            @test isa(Ftm_G,Vector{GeometryBasics.TriangleFace{Int64}})
+            @test isa(Ftm_G,Vector{GeometryBasics.TriangleFace{Int}})
             @test length(Ftm_G) == 1
         end
 
         Fqm_G = tofaces([Fqm[1,:]])
         @testset "1 QuadFace" begin        
-            @test isa(Fqm_G,Vector{GeometryBasics.QuadFace{Int64}})
+            @test isa(Fqm_G,Vector{GeometryBasics.QuadFace{Int}})
             @test length(Fqm_G) == 1
         end
 
         Fnm_G = tofaces([Fnm[1,:]])
         @testset "1 NgonFace" begin        
-            @test isa(Fnm_G,Vector{GeometryBasics.NgonFace{5,Int64}})
+            @test isa(Fnm_G,Vector{GeometryBasics.NgonFace{5,Int}})
             @test length(Fnm_G) == 1
         end  
         
         Fem_G = tofaces(Fem)
         @testset "LineFace" begin        
-            @test isa(Fem_G,Vector{GeometryBasics.LineFace{Int64}})
+            @test isa(Fem_G,Vector{GeometryBasics.LineFace{Int}})
             @test length(Fem_G) == size(Fem,1)
         end
 
         Ftm_G = tofaces(Ftm)
         @testset "TriangleFace" begin        
-            @test isa(Ftm_G,Vector{GeometryBasics.TriangleFace{Int64}})
+            @test isa(Ftm_G,Vector{GeometryBasics.TriangleFace{Int}})
             @test length(Ftm_G) == size(Ftm,1)
         end
 
         Fqm_G = tofaces(Fqm)
         @testset "QuadFace" begin        
-            @test isa(Fqm_G,Vector{GeometryBasics.QuadFace{Int64}})
+            @test isa(Fqm_G,Vector{GeometryBasics.QuadFace{Int}})
             @test length(Fqm_G) == size(Fqm,1)
         end
 
         Fnm_G = tofaces(Fnm)
         @testset "NgonFace" begin        
-            @test isa(Fnm_G,Vector{GeometryBasics.NgonFace{5,Int64}})
+            @test isa(Fnm_G,Vector{GeometryBasics.NgonFace{5,Int}})
             @test length(Fnm_G) == size(Fnm,1)
         end        
     end
@@ -1030,55 +1030,55 @@ end
     @testset "vector input" verbose = true begin        
         Fev_G = tofaces([Fev[1]])        
         @testset "1 LineFace" begin        
-            @test isa(Fev_G,Vector{GeometryBasics.LineFace{Int64}})
+            @test isa(Fev_G,Vector{GeometryBasics.LineFace{Int}})
             @test length(Fev_G) == 1
         end
 
         Ftv_G = tofaces([Ftv[1]])        
         @testset "1 TriangleFace" begin        
-            @test isa(Ftv_G,Vector{GeometryBasics.TriangleFace{Int64}})
+            @test isa(Ftv_G,Vector{GeometryBasics.TriangleFace{Int}})
             @test length(Ftv_G) == 1
         end
 
         Fqv_G = tofaces([Fqv[1]])
         @testset "1 QuadFace" begin        
-            @test isa(Fqv_G,Vector{GeometryBasics.QuadFace{Int64}})
+            @test isa(Fqv_G,Vector{GeometryBasics.QuadFace{Int}})
             @test length(Fqv_G) == 1
         end
 
         Fnv_G = tofaces([Fnv[1]])
         @testset "1 NgonFace" begin        
-            @test isa(Fnv_G,Vector{GeometryBasics.NgonFace{5,Int64}})
+            @test isa(Fnv_G,Vector{GeometryBasics.NgonFace{5,Int}})
             @test length(Fnv_G) == 1
         end  
 
         Fev_G = tofaces(Fev)        
         @testset "LineFace" begin        
-            @test isa(Fev_G,Vector{GeometryBasics.LineFace{Int64}})
+            @test isa(Fev_G,Vector{GeometryBasics.LineFace{Int}})
             @test length(Fev_G) == length(Fev)
         end
 
         Ftv_G = tofaces(Ftv)
         @testset "TriangleFace" begin        
-            @test isa(Ftv_G,Vector{GeometryBasics.TriangleFace{Int64}})
+            @test isa(Ftv_G,Vector{GeometryBasics.TriangleFace{Int}})
             @test length(Ftv_G) == length(Ftv)
         end
 
         Fqv_G = tofaces(Fqv)
         @testset "QuadFace" begin        
-            @test isa(Fqv_G,Vector{GeometryBasics.QuadFace{Int64}})
+            @test isa(Fqv_G,Vector{GeometryBasics.QuadFace{Int}})
             @test length(Fqv_G) == length(Fqv)
         end
 
         Fnv_G = tofaces(Fnv)
         @testset "NgonFace" begin        
-            @test isa(Fnv_G,Vector{GeometryBasics.NgonFace{5,Int64}})
+            @test isa(Fnv_G,Vector{GeometryBasics.NgonFace{5,Int}})
             @test length(Fnv_G) == length(Fnv)
         end    
         
         Fnv_G2 = tofaces(Fnv_G)
         @testset "NgonFace no change" begin        
-            @test isa(Fnv_G2,Vector{GeometryBasics.NgonFace{5,Int64}})
+            @test isa(Fnv_G2,Vector{GeometryBasics.NgonFace{5,Int}})
             @test length(Fnv_G2) == length(Fnv_G)
         end    
 
@@ -1097,28 +1097,28 @@ end
 
             @testset "edges" begin
                 F = tofaces(Fme)
-                @test isa(F,Vector{GeometryBasics.LineFace{Int64}})
+                @test isa(F,Vector{GeometryBasics.LineFace{Int}})
                 @test length(F) == length(Fme)
                 @test Fme[1] == F[1]
             end  
 
             @testset "Triangles" begin
                 F = tofaces(Fmt)
-                @test isa(F,Vector{GeometryBasics.TriangleFace{Int64}})
+                @test isa(F,Vector{GeometryBasics.TriangleFace{Int}})
                 @test length(F) == length(Fmt)
                 @test Fmt[1] == F[1]
             end
 
             @testset "Quads" begin
                 F = tofaces(Fmq)
-                @test isa(F,Vector{GeometryBasics.QuadFace{Int64}})
+                @test isa(F,Vector{GeometryBasics.QuadFace{Int}})
                 @test length(F) == length(Fmq)
                 @test Fmq[1] == F[1]
             end
 
             @testset "NgonFace" begin
                 F = tofaces(Fmn)
-                @test isa(F,Vector{GeometryBasics.NgonFace{5,Int64}})
+                @test isa(F,Vector{GeometryBasics.NgonFace{5,Int}})
                 @test length(F) == length(Fmn)
                 @test Fmn[1] == F[1]
             end
@@ -1239,7 +1239,7 @@ end
 
 @testset "edgecrossproduct" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]
+        F = [TriangleFace{Int}(1, 2, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,3)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1248,7 +1248,7 @@ end
         @test C == [Vec3{Float64}(0.0,0.0,0.5)]
     end
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1258,7 +1258,7 @@ end
         @test C == [Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1268,7 +1268,7 @@ end
         @test C == [Vec3{Float64}(0.0,0.0,0.5),Vec3{Float64}(0.0,0.0,-0.5)]
     end
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,6)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1291,7 +1291,7 @@ end
 
 @testset "facenormal" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]
+        F = [TriangleFace{Int}(1, 2, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,3)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1300,7 +1300,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1310,7 +1310,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1320,7 +1320,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,-1.0)]
     end
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,6)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1339,7 +1339,7 @@ end
 
 @testset "facearea" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]
+        F = [TriangleFace{Int}(1, 2, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,3)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1348,7 +1348,7 @@ end
         @test A == [0.5]
     end
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1358,7 +1358,7 @@ end
         @test A == [1.0]
     end
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1368,7 +1368,7 @@ end
         @test A == [0.5,0.5]
     end
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,6)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1387,7 +1387,7 @@ end
 
 @testset "vertexnormal" verbose = true begin
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]
+        F = [TriangleFace{Int}(1, 2, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,3)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1396,7 +1396,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1406,7 +1406,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1416,7 +1416,7 @@ end
         @test N == [Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0),Vec3{Float64}(0.0,0.0,1.0)]
     end
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(3,4,5,6)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(3,4,5,6)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,6)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1435,7 +1435,7 @@ end
 
 @testset "edgelengths" begin
     @testset "GeometryBasics faces, vertices" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
         V[2] = GeometryBasics.Point{3, Float64}(1.0, 0.0, 0.0)
@@ -1447,7 +1447,7 @@ end
     end
 
     @testset "GeometryBasics LineFace edges" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]
+        F = [QuadFace{Int}(1, 2, 3, 4)]
         E = meshedges(F)
         V = Vector{GeometryBasics.Point{3, Float64}}(undef,4)
         V[1] = GeometryBasics.Point{3, Float64}(0.0, 0.0, 0.0)
@@ -1483,7 +1483,7 @@ end
         @test Vn == V
 
         Fn, Vn = subtri(F, V, n; method=:linear)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
 
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
@@ -1500,7 +1500,7 @@ end
         @test Vn == V
 
         Fn, Vn = subtri(F, V, n; method=:Loop)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
 
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
@@ -1524,7 +1524,7 @@ end
         @test Vn == V
 
         Fn, Vn = subtri(F, V, n; method=:Loop, constrain_boundary=false)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
 
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
@@ -1547,7 +1547,7 @@ end
         @test Vn == V
 
         Fn, Vn = subtri(F, V, n; method=:Loop, constrain_boundary=true)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
 
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
@@ -1595,7 +1595,7 @@ end
         @test Vn == V
 
         Fn, Vn = subquad(F, V, n; method=:linear)        
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
         @test eltype(V) == eltype(Vn)  
@@ -1611,7 +1611,7 @@ end
         @test Vn == V
 
         Fn, Vn = subquad(F, V, n; method=:Catmull_Clark)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
         @test eltype(V) == eltype(Vn)  
@@ -1634,7 +1634,7 @@ end
         @test Vn == V
 
         Fn, Vn = subquad(F, V, n; method=:Catmull_Clark, constrain_boundary=false)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
         @test eltype(V) == eltype(Vn)  
@@ -1656,7 +1656,7 @@ end
         @test Vn == V
 
         Fn, Vn = subquad(F, V, n; method=:Catmull_Clark, constrain_boundary=true)
-        ind = round.(Int64,range(1,length(Vn),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vn),6)) # Sample indices
         @test eltype(F) == eltype(Fn)
         @test length(Fn) == 4^n*length(F)        
         @test eltype(V) == eltype(Vn)  
@@ -1682,8 +1682,8 @@ end
     
     n = 3
     F, V = geosphere(n, r)    
-    ind = round.(Int64,range(1,length(V),6)) # Sample indices
-    @test F isa Vector{TriangleFace{Int64}}
+    ind = round.(Int,range(1,length(V),6)) # Sample indices
+    @test F isa Vector{TriangleFace{Int}}
     @test length(F) == 4^n*20    # 20 since the icosahedron is the start geometry
     @test V isa Vector{Point{3,Float64}}    
     @test isapprox(V[ind],GeometryBasics.Point{3, Float64}[[0.0, -0.5257311121191336, -0.85065080835204], 
@@ -1699,8 +1699,8 @@ end
         E,V,F,Fb,CFb_type = hexbox([1.0,1.0,1.0],[1,1,1])
         @test E == [[1, 2, 4, 3, 5, 6, 8, 7]] 
         @test V == Point3{Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
-        @test F == QuadFace{Int64}[[3, 4, 2, 1], [5, 6, 8, 7], [1, 2, 6, 5], [4, 3, 7, 8], [2, 4, 8, 6], [5, 7, 3, 1]]
-        @test Fb == QuadFace{Int64}[[3, 4, 2, 1], [5, 6, 8, 7], [1, 2, 6, 5], [4, 3, 7, 8], [2, 4, 8, 6], [5, 7, 3, 1]]
+        @test F == QuadFace{Int}[[3, 4, 2, 1], [5, 6, 8, 7], [1, 2, 6, 5], [4, 3, 7, 8], [2, 4, 8, 6], [5, 7, 3, 1]]
+        @test Fb == QuadFace{Int}[[3, 4, 2, 1], [5, 6, 8, 7], [1, 2, 6, 5], [4, 3, 7, 8], [2, 4, 8, 6], [5, 7, 3, 1]]
         @test CFb_type == [1, 2, 3, 4, 5, 6]
     end
     @testset "2x2x2 hex box" begin
@@ -1718,7 +1718,7 @@ end
 
 @testset "con_face_edge" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
 
@@ -1730,7 +1730,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
 
@@ -1742,13 +1742,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_F2E = con_face_edge(F)
         @test con_F2E == [[1,2,4],[2,3,5]]        
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_F2E = con_face_edge(F)
         @test con_F2E == [[1,3,2,6],[2,4,5,7]]        
     end
@@ -1757,7 +1757,7 @@ end
 
 @testset "con_edge_face" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
 
@@ -1769,7 +1769,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
 
@@ -1781,13 +1781,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_E2F = con_edge_face(F)
         @test con_E2F == [[1], [1, 2], [2], [1], [2]]       
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_E2F = con_edge_face(F)
         @test con_E2F == [[1], [1, 2], [1], [2], [2], [1], [2]]       
     end
@@ -1796,7 +1796,7 @@ end
 
 @testset "con_face_face" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
         con_E2F = con_edge_face(F)
@@ -1811,7 +1811,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
         con_E2F = con_edge_face(F)
@@ -1825,13 +1825,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_F2F = con_face_face(F)
         @test con_F2F == [[2], [1]]       
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_F2F = con_face_face(F)
         @test con_F2F == [[2], [1]]       
     end
@@ -1840,7 +1840,7 @@ end
 
 @testset "con_face_face_v" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
         con_V2F = con_vertex_face(F,V) 
 
@@ -1852,7 +1852,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
         con_V2F = con_vertex_face(F,V)
 
@@ -1864,13 +1864,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_F2F = con_face_face_v(F)
         @test con_F2F == [[2], [1]]       
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_F2F = con_face_face_v(F)
         @test con_F2F == [[2], [1]]       
     end
@@ -1879,7 +1879,7 @@ end
 
 @testset "con_vertex_simplex" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
 
         con_V2F = con_vertex_simplex(F)
@@ -1890,7 +1890,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
 
         con_V2F = con_vertex_simplex(F)
@@ -1901,13 +1901,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_V2F = con_vertex_simplex(F)
         @test con_V2F == [[1], [1, 2], [1, 2], [2]]      
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_V2F = con_vertex_simplex(F)
         @test con_V2F == [[1], [1], [1, 2], [1, 2], [2], [2]]  
     end
@@ -1916,7 +1916,7 @@ end
 
 @testset "con_vertex_face" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
 
         con_V2F = con_vertex_face(F)
@@ -1927,7 +1927,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
 
         con_V2F = con_vertex_face(F)
@@ -1938,13 +1938,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]        
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]        
         con_V2F = con_vertex_face(F)
         @test con_V2F == [[1], [1, 2], [1, 2], [2]]      
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         con_V2F = con_vertex_face(F)
         @test con_V2F == [[1], [1], [1, 2], [1, 2], [2], [2]]  
     end
@@ -1953,7 +1953,7 @@ end
 
 @testset "con_vertex_edge" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         E = meshedges(F)
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
 
@@ -1965,7 +1965,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         E = meshedges(F)
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
 
@@ -1977,14 +1977,14 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]     
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]     
         E = meshedges(F)  
         con_V2E = con_vertex_edge(E)
         @test con_V2E == [[1, 5], [1, 2, 3, 6], [2, 3, 4, 5], [4, 6]]    
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]        
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]        
         E = meshedges(F)
         con_V2E = con_vertex_edge(E)
         @test con_V2E == [[1, 7], [1, 3], [2, 3, 5, 8], [2, 4, 5, 7], [4, 6], [6, 8]]
@@ -1994,7 +1994,7 @@ end
 
 @testset "con_edge_edge" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
         con_V2E = con_vertex_edge(E_uni) 
@@ -2007,7 +2007,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
         con_V2E = con_vertex_edge(E_uni) 
@@ -2020,7 +2020,7 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]       
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]       
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
         con_E2E = con_edge_edge(E_uni)
@@ -2028,7 +2028,7 @@ end
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]      
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]      
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)      
         con_E2E = con_edge_edge(E_uni)
@@ -2039,7 +2039,7 @@ end
 
 @testset "con_vertex_vertex_f" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]        
+        F = TriangleFace{Int}[[1,2,3]]        
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
         con_V2F = con_vertex_face(F)
 
@@ -2051,7 +2051,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]        
+        F = QuadFace{Int}[[1,2,3,4]]        
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
         con_V2F = con_vertex_face(F)
 
@@ -2063,13 +2063,13 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]             
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]             
         con_V2V = con_vertex_vertex_f(F)
         @test con_V2V == [[2, 3], [1, 3, 4], [1, 2, 4], [2, 3]]   
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]                
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]                
         con_V2V = con_vertex_vertex_f(F)
         @test con_V2V == [[2, 3, 4], [1, 3, 4], [1, 2, 4, 5, 6], [1, 2, 3, 5, 6], [3, 4, 6], [3, 4, 5]]
     end
@@ -2078,7 +2078,7 @@ end
 
 @testset "con_vertex_vertex" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]        
+        F = TriangleFace{Int}[[1,2,3]]        
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
@@ -2092,7 +2092,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]        
+        F = QuadFace{Int}[[1,2,3,4]]        
         V = [Point3{Float64}(rand(4)) for _ in 1:4]        
         E = meshedges(F;unique_only=false)
         E_uni,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)    
@@ -2106,14 +2106,14 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]      
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]      
         E = meshedges(F;unique_only=false)       
         con_V2V = con_vertex_vertex(E)
         @test con_V2V == [[2, 3], [1, 3, 4], [2, 4, 1], [3, 2]]
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]                
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]                
         E = meshedges(F;unique_only=false)
         con_V2V = con_vertex_vertex(E)
         @test con_V2V == [[2, 4], [1, 3], [4, 2, 6], [3, 5, 1], [4, 6], [5, 3]]
@@ -2123,7 +2123,7 @@ end
 
 @testset "meshconnectivity" verbose = true begin    
     @testset "Single triangle" begin
-        F = TriangleFace{Int64}[[1,2,3]]        
+        F = TriangleFace{Int}[[1,2,3]]        
         V = [Point3{Float64}(rand(3)) for _ in 1:3]        
 
         # EDGE-VERTEX connectivity
@@ -2173,7 +2173,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = QuadFace{Int64}[[1,2,3,4]]        
+        F = QuadFace{Int}[[1,2,3,4]]        
         V = [Point3{Float64}(rand(4)) for _ in 1:4]   
 
         # EDGE-VERTEX connectivity
@@ -2223,7 +2223,7 @@ end
     end
 
     @testset "Triangles" begin
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]      
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]      
         V = [Point3{Float64}(rand(4)) for _ in 1:4]   
 
         # EDGE-VERTEX connectivity
@@ -2273,7 +2273,7 @@ end
     end
 
     @testset "Quads" begin
-        F = QuadFace{Int64}[[1,2,3,4],[3,4,5,6]]                
+        F = QuadFace{Int}[[1,2,3,4],[3,4,5,6]]                
         V = [Point3{Float64}(rand(4)) for _ in 1:6]   
         
         # EDGE-VERTEX connectivity
@@ -2336,7 +2336,7 @@ end
     @test length(Vm) == length(V)
     @test isapprox(Vm[1], [-1.0, -1.0, -1.0], atol=eps_level)
     @test [indReverse[f] for f in Fm] == Fs # Reverse mapping 
-    @test Fm isa Vector{QuadFace{Int64}} # Face type unaltered 
+    @test Fm isa Vector{QuadFace{Int}} # Face type unaltered 
     @test length(Fm) == length(F) # Length is correct
     @test Fm[1] == [1, 2, 3, 4]
 
@@ -2346,7 +2346,7 @@ end
     @test length(Vm) == length(V)
     @test isapprox(Vm[1], [-1.0, -1.0, -1.0], atol=eps_level)
     @test [indReverse[f] for f in Fm] == Fs # Reverse mapping 
-    @test Fm isa Vector{QuadFace{Int64}} # Face type unaltered 
+    @test Fm isa Vector{QuadFace{Int}} # Face type unaltered 
     @test length(Fm) == length(F) # Length is correct
     @test Fm[1] == [1, 2, 3, 4]
 end
@@ -2360,7 +2360,7 @@ end
     V = coordinates(M)
     F,V = subtri(F,V,3)
 
-    ind = round.(Int64,range(1,length(V),5))
+    ind = round.(Int,range(1,length(V),5))
 
     @testset "errors" begin
         λ = -0.5 # Laplacian smoothing parameter
@@ -2416,7 +2416,7 @@ end
     V = coordinates(M)
     F,V = subtri(F,V,3)
 
-    ind = round.(Int64,range(1,length(V),5))
+    ind = round.(Int,range(1,length(V),5))
 
     @testset "errors" begin
         n=10
@@ -2500,7 +2500,7 @@ end
     @test V isa Vector{Point3{Float64}}
     @test length(V) == prod(plateElem.+1)
     @test isapprox(V, Point3{Float64}[[-2.5, -2.5, 0.0], [-1.25, -2.5, 0.0], [0.0, -2.5, 0.0], [1.25, -2.5, 0.0], [2.5, -2.5, 0.0], [-2.5, -0.8333333333333334, 0.0], [-1.25, -0.8333333333333334, 0.0], [0.0, -0.8333333333333334, 0.0], [1.25, -0.8333333333333334, 0.0], [2.5, -0.8333333333333334, 0.0], [-2.5, 0.8333333333333334, 0.0], [-1.25, 0.8333333333333334, 0.0], [0.0, 0.8333333333333334, 0.0], [1.25, 0.8333333333333334, 0.0], [2.5, 0.8333333333333334, 0.0], [-2.5, 2.5, 0.0], [-1.25, 2.5, 0.0], [0.0, 2.5, 0.0], [1.25, 2.5, 0.0], [2.5, 2.5, 0.0]], atol=eps_level)
-    @test F isa Vector{QuadFace{Int64}}
+    @test F isa Vector{QuadFace{Int}}
     @test length(F) == prod(plateElem)
     @test F[1] == [1, 2, 7, 6]
 end
@@ -2515,7 +2515,7 @@ end
     @test V isa Vector{Point3{Float64}}
     @test length(V) == 386
     @test isapprox(V[1], [-0.5773502691896258, -0.5773502691896258, -0.5773502691896258], atol=eps_level)
-    @test F isa Vector{QuadFace{Int64}}
+    @test F isa Vector{QuadFace{Int}}
     @test length(F) == 384
     @test F[1] == [1, 99, 291, 187]
 end
@@ -2524,7 +2524,7 @@ end
     eps_level = 1e-4
 
     # Single face/element
-    F1 = QuadFace{Int64}[[1,2,3,4]]
+    F1 = QuadFace{Int}[[1,2,3,4]]
     V1 = [GeometryBasics.Point3(rand(3)) for _=1:length(F1[1])]
 
     # A quad mesh featuring a variation in terms of face areas and vertex connectivity 
@@ -2739,7 +2739,7 @@ end
     @testset "Triangles" begin
         F, V = geosphere(2, 1.0)
         VC = simplexcenter(F, V)
-        ind = round.(Int64,range(1,length(VC),5))
+        ind = round.(Int,range(1,length(VC),5))
 
         @test VC isa typeof(V)
         @test length(VC) == length(F)
@@ -2749,7 +2749,7 @@ end
     @testset "Quadrilaterals" begin
         F, V = quadsphere(2, 1.0)
         VC = simplexcenter(F, V)
-        ind = round.(Int64,range(1,length(VC),5))
+        ind = round.(Int,range(1,length(VC),5))
         @test VC isa typeof(V)
         @test length(VC) == length(F)
         @test isapprox(VC[ind], Point3{Float64}[[-0.4802860138667546, -0.4802860138667546, -0.6949720954766154], [-0.4802860138667546, 0.4802860138667546, 0.6949720954766154], [-0.7899092719339054, -0.16747661189958585, -0.5326696383253359], [0.7899092719339054, -0.16747661189958585, 0.5326696383253359], [0.16747661189958585, -0.7899092719339054, -0.5326696383253359]], atol=eps_level)
@@ -2804,7 +2804,7 @@ end
         r = 2.0
         n = 40
         V = circlepoints(r, n; dir=:acw)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         d = [sqrt(sum(v.^2)) for v in V]
         @test V isa Vector{Point3{Float64}}
         @test length(V) == n
@@ -2815,7 +2815,7 @@ end
         [1.9753766811902753, -0.31286893008046224, 0.0]], atol=eps_level)
    
         V = circlepoints(r, n; dir=:cw)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         d = [sqrt(sum(v.^2)) for v in V]
         @test V isa Vector{Point3{Float64}}
         @test length(V) == n
@@ -2830,7 +2830,7 @@ end
         n = 40
         rFun(t) = r + 0.5 .* sin(3 * t)
         V = circlepoints(rFun, n)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
         @test V isa Vector{Point3{Float64}}
         @test length(V) == n
@@ -2839,7 +2839,7 @@ end
         [0.7634877789282826, -0.12092458456017953, 0.0]], atol=eps_level)
        
         V = circlepoints(rFun, n; dir=:cw)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
         @test V isa Vector{Point3{Float64}}
         @test length(V) == n
@@ -2867,9 +2867,9 @@ end
 
     @testset "quad" begin
         F,V = loftlinear(V1,V2;num_steps=num_steps,close_loop=true,face_type=:quad)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == nc*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2877,15 +2877,15 @@ end
 
         # Providing "nothing" for the number of steps should create point spacing based number of steps
         F,V = loftlinear(V1,V2;num_steps=nothing,close_loop=true,face_type=:quad)
-        @test length(V)/nc == ceil(Int64,norm(n)/(0.5*(pointspacingmean(V1)+pointspacingmean(V2))))
+        @test length(V)/nc == ceil(Int,norm(n)/(0.5*(pointspacingmean(V1)+pointspacingmean(V2))))
 
     end
 
     @testset "tri" begin
         F,V = loftlinear(V1,V2;num_steps=num_steps,close_loop=true,face_type=:tri)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2894,9 +2894,9 @@ end
 
     @testset "tri_slash" begin
         F,V = loftlinear(V1,V2;num_steps=num_steps,close_loop=true,face_type=:tri_slash)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2905,9 +2905,9 @@ end
 
     @testset "quad2tri" begin
         F,V = loftlinear(V1,V2;num_steps=num_steps,close_loop=true,face_type=:quad2tri)
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2934,7 +2934,7 @@ end
         #Non-closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=false,face_type=:quad)
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2943,7 +2943,7 @@ end
         # Closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=true,face_type=:quad)
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == nc*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2952,7 +2952,7 @@ end
         # 3 layers
         num_steps = 3
         F,V = loftpoints2surf(Vp3,num_steps; close_loop=true,face_type=:quad)
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == nc*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2963,7 +2963,7 @@ end
         #Non-closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=false,face_type=:tri_slash)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2972,7 +2972,7 @@ end
         # Closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=true,face_type=:tri_slash)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2981,7 +2981,7 @@ end
         # 3 layers
         num_steps = 3
         F,V = loftpoints2surf(Vp3,num_steps; close_loop=true,face_type=:tri_slash)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -2992,7 +2992,7 @@ end
         #Non-closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=false,face_type=:tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3001,7 +3001,7 @@ end
         # Closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=true,face_type=:tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3010,7 +3010,7 @@ end
         # 3 layers
         num_steps = 3
         F,V = loftpoints2surf(Vp3,num_steps; close_loop=true,face_type=:tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3021,7 +3021,7 @@ end
         #Non-closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=false,face_type=:quad2tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3030,7 +3030,7 @@ end
         # Closed loop
         num_steps = 2
         F,V = loftpoints2surf(Vp2,num_steps; close_loop=true,face_type=:quad2tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3039,7 +3039,7 @@ end
         # 3 layers
         num_steps = 3
         F,V = loftpoints2surf(Vp3,num_steps; close_loop=true,face_type=:quad2tri)
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -3068,9 +3068,9 @@ end
     end
 
     @testset "Styles" begin
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
-        @test typeof(hp2) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
-        @test typeof(hp3) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}        
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
+        @test typeof(hp2) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
+        @test typeof(hp3) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}        
         @test length(faces(Mp)) == length(V)
     end
 end
@@ -3093,17 +3093,17 @@ end
     @testset "type_flag options" begin
         hp1 =  normalplot(ax,M; type_flag=:face, color=:black,linewidth=3,scaleval=nothing)
         Mp = hp1[1].val
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
         @test length(faces(Mp)) == length(F)
 
         hp1 =  normalplot(ax,M; type_flag=:vertex, color=:black,linewidth=3,scaleval=nothing)
         Mp = hp1[1].val
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
         @test length(faces(Mp)) == length(V)
 
         hp1 =  normalplot(ax,F,V; type_flag=:vertex, color=:black,linewidth=3,scaleval=nothing)
         Mp = hp1[1].val
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
         @test length(faces(Mp)) == length(V)
 
         fileName_mesh = joinpath(comododir(),"assets","obj","spot_control_mesh.obj")
@@ -3113,18 +3113,18 @@ end
 
         hp1 =  normalplot(ax,F,V; type_flag=:vertex, color=:black,linewidth=3,scaleval=nothing)
         Mp = hp1[1].val
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float32, Line{3, Float32}, SimpleFaceView{3, Float32, 2, Int64, Point3{Float32}, LineFace{Int64}}}}}
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float32, Line{3, Float32}, SimpleFaceView{3, Float32, 2, Int, Point3{Float32}, LineFace{Int}}}}}
         @test length(faces(Mp)) == length(V)
 
         hp1 =  normalplot(ax,Mn; type_flag=:face)
         Mp = hp1[1].val
-        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float32, Line{3, Float32}, SimpleFaceView{3, Float32, 2, Int64, Point3{Float32}, LineFace{Int64}}}}}
+        @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float32, Line{3, Float32}, SimpleFaceView{3, Float32, 2, Int, Point3{Float32}, LineFace{Int}}}}}
         @test length(faces(Mp)) == length(F)
 
         # Not supported yet
         # hp1 =  normalplot(ax,F,V; type_flag=:vertex, color=:black,linewidth=3,scaleval=nothing)
         # Mp = hp1[1].val
-        # @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int64, Point3{Float64}, LineFace{Int64}}}}}
+        # @test typeof(hp1) == Wireframe{Tuple{GeometryBasics.Mesh{3, Float64, Line{3, Float64}, SimpleFaceView{3, Float64, 2, Int, Point3{Float64}, LineFace{Int}}}}}
         # @test length(faces(Mp)) == length(V)
 
     end
@@ -3185,19 +3185,19 @@ end
 
     @testset "convert_method variations" begin
         Ft = quad2tri(F,V; convert_method = :forward)
-        @test Ft ==TriangleFace{Int64}[TriangleFace(1, 2, 3), TriangleFace(3, 4, 1), 
+        @test Ft ==TriangleFace{Int}[TriangleFace(1, 2, 3), TriangleFace(3, 4, 1), 
         TriangleFace(8, 7, 6), TriangleFace(6, 5, 8), TriangleFace(5, 6, 2), 
         TriangleFace(2, 1, 5), TriangleFace(6, 7, 3), TriangleFace(3, 2, 6), 
         TriangleFace(7, 8, 4), TriangleFace(4, 3, 7), TriangleFace(8, 5, 1), TriangleFace(1, 4, 8)]
         
         Ft = quad2tri(F,V; convert_method = :backward)
-        @test Ft == TriangleFace{Int64}[TriangleFace(1, 2, 4), TriangleFace(2, 3, 4), 
+        @test Ft == TriangleFace{Int}[TriangleFace(1, 2, 4), TriangleFace(2, 3, 4), 
         TriangleFace(8, 7, 5), TriangleFace(7, 6, 5), TriangleFace(5, 6, 1), 
         TriangleFace(6, 2, 1), TriangleFace(6, 7, 2), TriangleFace(7, 3, 2), 
         TriangleFace(7, 8, 3), TriangleFace(8, 4, 3), TriangleFace(8, 5, 4), TriangleFace(5, 1, 4)]
 
         Ft = quad2tri(F,V; convert_method = :angle)
-        @test Ft == TriangleFace{Int64}[TriangleFace(1, 2, 4), TriangleFace(2, 3, 4), 
+        @test Ft == TriangleFace{Int}[TriangleFace(1, 2, 4), TriangleFace(2, 3, 4), 
         TriangleFace(8, 7, 6), TriangleFace(6, 5, 8), TriangleFace(5, 6, 2), 
         TriangleFace(2, 1, 5), TriangleFace(6, 7, 3), TriangleFace(3, 2, 6), 
         TriangleFace(7, 8, 3), TriangleFace(8, 4, 3), TriangleFace(8, 5, 4), TriangleFace(5, 1, 4)]
@@ -3211,13 +3211,13 @@ end
     F = [F[i] for i in findall(map(v -> v[3] > 0, VC))] # Remove some faces
     Fn, Vn = remove_unused_vertices(F, V)
 
-    @test Fn isa Vector{TriangleFace{Int64}}
+    @test Fn isa Vector{TriangleFace{Int}}
     @test Vn isa Vector{Point3{Float64}}
     @test length(F) == length(Fn)
     @test length(Vn) ==  maximum(reduce(vcat,Fn))
     
     # Check empty results
-    Fn, Vn = remove_unused_vertices(Vector{TriangleFace{Int64}}(), V)
+    Fn, Vn = remove_unused_vertices(Vector{TriangleFace{Int}}(), V)
     @test isempty(Fn)
     @test isempty(Vn)
 
@@ -3281,7 +3281,7 @@ end
 
     
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]       
+        F = [TriangleFace{Int}(1, 2, 3)]       
         E = meshedges(F)
         Eu,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)
         count_E2F = count_edge_face(F,Eu,indReverse)
@@ -3294,7 +3294,7 @@ end
     end
 
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]       
+        F = [QuadFace{Int}(1, 2, 3, 4)]       
         E = meshedges(F)
         Eu,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)
         count_E2F = count_edge_face(F,Eu,indReverse)
@@ -3302,7 +3302,7 @@ end
     end
 
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         E = meshedges(F)
         Eu,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)
         count_E2F = count_edge_face(F,Eu,indReverse)
@@ -3310,7 +3310,7 @@ end
     end
 
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         E = meshedges(F)
         Eu,_,indReverse = gunique(E; return_unique=true, return_index=true, return_inverse=true, sort_entries=true)
         count_E2F = count_edge_face(F,Eu,indReverse)
@@ -3323,33 +3323,33 @@ end
 @testset "boundaryedges" verbose = true begin
 
     @testset "Set of edges" begin
-        E = LineFace{Int64}[[1,2],[2,1],[3,1],[4,2],[2,4]]
+        E = LineFace{Int}[[1,2],[2,1],[3,1],[4,2],[2,4]]
         Eb = boundaryedges(E)
-        @test Eb == LineFace{Int64}[[3, 1]]
+        @test Eb == LineFace{Int}[[3, 1]]
     end
 
     @testset "Single triangle" begin
-        F = [TriangleFace{Int64}(1, 2, 3)]       
+        F = [TriangleFace{Int}(1, 2, 3)]       
         Eb = boundaryedges(F)
-        @test Eb == LineFace{Int64}[[1, 2], [2, 3], [3, 1]]
+        @test Eb == LineFace{Int}[[1, 2], [2, 3], [3, 1]]
     end
 
     @testset "Single quad" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4)]       
+        F = [QuadFace{Int}(1, 2, 3, 4)]       
         Eb = boundaryedges(F)
-        @test Eb == LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 1]]
+        @test Eb == LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 1]]
     end
 
     @testset "Triangles" begin
-        F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(1, 4, 3)]
+        F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(1, 4, 3)]
         Eb = boundaryedges(F)
-        @test Eb == LineFace{Int64}[[1, 2], [1, 4], [2, 3], [4, 3]]
+        @test Eb == LineFace{Int}[[1, 2], [1, 4], [2, 3], [4, 3]]
     end
 
     @testset "Quads" begin
-        F = [QuadFace{Int64}(1, 2, 3, 4),QuadFace{Int64}(6, 5, 4, 3)]
+        F = [QuadFace{Int}(1, 2, 3, 4),QuadFace{Int}(6, 5, 4, 3)]
         Eb = boundaryedges(F)
-        @test Eb == LineFace{Int64}[[1, 2], [6, 5], [2, 3], [5, 4], [4, 1], [3, 6]]
+        @test Eb == LineFace{Int}[[1, 2], [6, 5], [2, 3], [5, 4], [4, 1], [3, 6]]
     end
 
 end
@@ -3390,7 +3390,7 @@ end
         sampleSize = 10
         pointSpacing = 2
         boxDim = sampleSize.*[1,1,1] # Dimensionsions for the box in each direction
-        boxEl = ceil.(Int64,boxDim./pointSpacing) # Number of elements to use in each direction 
+        boxEl = ceil.(Int,boxDim./pointSpacing) # Number of elements to use in each direction 
         E,V,F,Fbq,CFb_type = hexbox(boxDim,boxEl)   
         F = element2faces(E)
 
@@ -3411,14 +3411,14 @@ end
         F = faces(M)        
         indB = boundaryfaceindices(F)
         @test sort(indB) == collect(1:length(F))
-        @test typeof(indB) == Vector{Int64}
+        @test typeof(indB) == Vector{Int}
     end
 
     @testset "Sphere mesh (all boundary faces)" begin
         F,V = geosphere(2,1.0)        
         indB = boundaryfaceindices(F)
         @test sort(indB) == collect(1:length(F))
-        @test typeof(indB) == Vector{Int64}
+        @test typeof(indB) == Vector{Int}
     end
 
     @testset "Tetrahedral mesh of a sphere" begin        
@@ -3435,7 +3435,7 @@ end
         sampleSize = 10
         pointSpacing = 2
         boxDim = sampleSize.*[1,1,1] # Dimensionsions for the box in each direction
-        boxEl = ceil.(Int64,boxDim./pointSpacing) # Number of elements to use in each direction 
+        boxEl = ceil.(Int,boxDim./pointSpacing) # Number of elements to use in each direction 
         E,V,F,Fbq,CFb_type = hexbox(boxDim,boxEl)   
         F = element2faces(E)
 
@@ -3448,29 +3448,29 @@ end
 @testset "edges2curve" begin
 
     # Empty input
-    E = LineFace{Int64}[]
+    E = LineFace{Int}[]
     ind = edges2curve(E)
     @test isempty(ind)
 
     # Open curve
-    E = LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 5]]
+    E = LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 5]]
     ind = edges2curve(E)
     @test ind == [1,2,3,4,5]
 
     # Closed curve
-    E = LineFace{Int64}[[1, 2], [2, 3], [3, 1]]
+    E = LineFace{Int}[[1, 2], [2, 3], [3, 1]]
     ind = edges2curve(E)
     @test ind == [1,2,3,1]
 
     # Disconnected edges
-    E = LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 5],[7,8]]
+    E = LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 5],[7,8]]
     @test_throws Exception edges2curve(E)
     
     # Invalid curve with branch
-    E = LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 5],[5,3]]
+    E = LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 5],[5,3]]
     @test_throws Exception edges2curve(E)
 
-    E = LineFace{Int64}[[1, 2], [2, 3], [3, 4], [4, 5],[5,3]]
+    E = LineFace{Int}[[1, 2], [2, 3], [3, 4], [4, 5],[5,3]]
     @test_throws Exception edges2curve(E)
 end
 
@@ -3485,14 +3485,14 @@ end
 
     @testset "Edges" begin
         V = Point3{Float64}[[0.0,0.0,0.0],[0.25,0.0,0.0],[0.75,0.0,0.0],[1.75,0.0,0.0]]
-        E = LineFace{Int64}[[1,2],[2,3],[3,4]]
+        E = LineFace{Int}[[1,2],[2,3],[3,4]]
         r = pointspacingmean(E,V)
         @test isapprox(r,mean(norm.(diff(V,dims=1))),atol = eps_level)
     end
 
     @testset "Faces" begin
         V = Point3{Float64}[[0.0,0.0,0.0],[0.25,0.0,0.0],[0.25,0.5,0.0],[0,0.5,0.0],[0.0,0.0,0.0]]
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         r = pointspacingmean(F,V)
         @test isapprox(r,mean(norm.(diff(V,dims=1))),atol = eps_level)
     end
@@ -3579,10 +3579,10 @@ end
         zMax = maximum(z)
         zMin = minimum(z)
 
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == nc*(num_steps-1)
 
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         @test V isa Vector{Point3{Float64}}
         @test isapprox(zMax,d,atol = eps_level) && isapprox(zMin,0.0,atol = eps_level)
         @test isapprox(V[ind],Point{3, Float64}[[1.0, 0.0, 0.0], [-1.8369701987210297e-16, 1.0, 0.75], 
@@ -3596,10 +3596,10 @@ end
         zMax = maximum(z)
         zMin = minimum(z)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
 
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         @test V isa Vector{Point3{Float64}}
         @test isapprox(zMax,d,atol = eps_level) && isapprox(zMin,0.0,atol = eps_level)
         @test isapprox(V[ind],Point{3, Float64}[[1.0, 0.0, 0.0], [-0.19134171618254525, 0.9619397662556433, 0.75], 
@@ -3613,10 +3613,10 @@ end
         zMax = maximum(z)
         zMin = minimum(z)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
 
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         @test V isa Vector{Point3{Float64}}
         @test isapprox(zMax,d,atol = eps_level) && isapprox(zMin,0.0,atol = eps_level)
         @test isapprox(V[ind],Point{3, Float64}[[1.0, 0.0, 0.0], [-1.8369701987210297e-16, 1.0, 0.75], 
@@ -3630,10 +3630,10 @@ end
         zMax = maximum(z)
         zMin = minimum(z)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc*(num_steps-1))*2
 
-        ind = round.(Int64,range(1,length(V),5))
+        ind = round.(Int,range(1,length(V),5))
         @test V isa Vector{Point3{Float64}}
         @test isapprox(zMax,d,atol = eps_level) && isapprox(zMin,0.0,atol = eps_level)
         @test isapprox(V[ind],Point{3, Float64}[[1.0, 0.0, 0.0], [-1.8369701987210297e-16, 1.0, 0.75], 
@@ -3647,53 +3647,53 @@ end
 @testset "meshgroup" verbose = true begin
 
     @testset "Errors" begin
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         @test_throws ArgumentError meshgroup(F; con_type=:wrong)
     end
 
     @testset "Single face" begin
         # Single triangle
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         C = meshgroup(F)
         @test C == [1]
 
         # Single triangle, edge connectivity
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         C = meshgroup(F; con_type=:e)
         @test C == [1]
         
         # Single quad
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         C = meshgroup(F)
         @test C == [1]
     end
 
     @testset "Two separate faces" begin
         # Two triangles separate
-        F = TriangleFace{Int64}[[1,2,3],[4,5,6]]
+        F = TriangleFace{Int}[[1,2,3],[4,5,6]]
         C = meshgroup(F)
         @test C == [1,2]
 
          # Two triangles, edge sharing 
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]
         C = meshgroup(F; con_type=:e)
         @test C == [1,1]
         
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4]]
+        F = TriangleFace{Int}[[1,2,3],[2,3,4]]
         C = meshgroup(F; con_type=:v)
         @test C == [1,1]
 
         # Two bow-tie triangles, node sharing 
-        F = TriangleFace{Int64}[[1,2,3],[3,4,5]]
+        F = TriangleFace{Int}[[1,2,3],[3,4,5]]
         C = meshgroup(F; con_type=:e)
         @test C == [1,2]
 
-        F = TriangleFace{Int64}[[1,2,3],[3,4,5]]
+        F = TriangleFace{Int}[[1,2,3],[3,4,5]]
         C = meshgroup(F; con_type=:v)
         @test C == [1,1]
         
         # Two quads
-        F = QuadFace{Int64}[[1,2,3,4],[5,6,7,8]]
+        F = QuadFace{Int}[[1,2,3,4],[5,6,7,8]]
         C = meshgroup(F)
         @test C == [1,2]
     end
@@ -3714,7 +3714,7 @@ end
 
     @testset "Two groups" begin
         # Three triangles two joined, one separate
-        F = TriangleFace{Int64}[[1,2,3],[2,3,4],[5,6,7]]
+        F = TriangleFace{Int}[[1,2,3],[2,3,4],[5,6,7]]
         C = meshgroup(F)
         @test C == [1,1,2]
         
@@ -3752,13 +3752,13 @@ end
 
     @testset "Single face" begin
         # Single triangle
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0]]
         d,dd,l = distmarch(F,V,[1])
         @test isapprox(d,[0.0,1.0,sqrt(2)],atol=eps_level)
 
         # Single triangle, un-used nodes
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0],
                             [1.0,0.0,0.0],[1.0,1.0,0.0]]
         d,dd,l = distmarch(F,V,[1])
@@ -3768,7 +3768,7 @@ end
         @test all(isnan.(d[.!b])) # Now check NaNs
 
         # Single quad
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0],[0.0,1.0,0.0]]
         d,dd,l = distmarch(F,V,[1])
         @test isapprox(d,[0.0,1.0,sqrt(2),1.0],atol=eps_level)
@@ -3778,14 +3778,14 @@ end
         # Bowtie triangle set
         V = Point3{Float64}[[0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [1.0, 0.0, 0.0], 
                             [2.0, 1.0, 0.0], [2.0, -1.0, 0.0]]
-        F = TriangleFace{Int64}[TriangleFace(1, 2, 3), TriangleFace(5, 4, 3)]
+        F = TriangleFace{Int}[TriangleFace(1, 2, 3), TriangleFace(5, 4, 3)]
         d,dd,l = distmarch(F,V,[1])
         @test isapprox(d,[0.0,2.0,sqrt(2),2*sqrt(2),2*sqrt(2)],atol=eps_level)
         
         # Two disconnected triangles
         V = Point3{Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], 
                             [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0]]
-        F = TriangleFace{Int64}[TriangleFace(1, 2, 3), TriangleFace(4, 5, 6)]
+        F = TriangleFace{Int}[TriangleFace(1, 2, 3), TriangleFace(4, 5, 6)]
         d,dd,l = distmarch(F,V,[1])
         r = [0.0,1.0,sqrt(2),NaN,NaN,NaN]
         b = .!isnan.(r)
@@ -3795,7 +3795,7 @@ end
         # Two disconnected quads
         V = Point3{Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0,1.0,0.0],
                             [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0,1.0,1.0]]
-        F = QuadFace{Int64}[QuadFace(1, 2, 3, 4), QuadFace(5, 6, 7, 8)]
+        F = QuadFace{Int}[QuadFace(1, 2, 3, 4), QuadFace(5, 6, 7, 8)]
         d,dd,l = distmarch(F,V,[1])
         r = [0.0,1.0,sqrt(2),1.0,NaN,NaN,NaN,NaN]
         b = .!isnan.(r)
@@ -3850,22 +3850,22 @@ end
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :ray, triSide = 1)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, 1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64}) # indIntersect == 3
+        @test isa(indIntersect,Vector{Int}) # indIntersect == 3
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :ray, triSide = 0)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, -1.0], [0.25, 0.0, 1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :ray, triSide = -1)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, -1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
 
         ray_origin = GeometryBasics.Point3{Float64}(0.0,0.0,1.5) # At centre so hits an edge between two triangles
         ray_vector = Vec3{Float64}(0.0,0.0,-1)
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :ray, triSide = 0, tolEps = 1e-3)
         @test isapprox(P,Point3{Float64}[[0.0, 0.0, -1.0], [0.0, 0.0, -1.0], 
                                          [0.0, 0.0,  1.0], [0.0, 0.0,  1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
     end
 
     @testset "line type" begin 
@@ -3874,27 +3874,27 @@ end
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :line, triSide = 1)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, 1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64}) # indIntersect == 3
+        @test isa(indIntersect,Vector{Int}) # indIntersect == 3
 
         ray_vector = Vec3{Float64}(0.0,0.0,-3) # Long so two hits potentially
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :line, triSide = 1)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, 1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64}) # indIntersect == 3
+        @test isa(indIntersect,Vector{Int}) # indIntersect == 3
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :line, triSide = 0)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, -1.0], [0.25, 0.0, 1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
 
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :line, triSide = -1)
         @test isapprox(P,Point3{Float64}[[0.25, 0.0, -1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
 
         ray_origin = GeometryBasics.Point3{Float64}(0.0,0.0,1.5) # At centre so hits an edge between two triangles
         P,indIntersect = ray_triangle_intersect(F,V,ray_origin,ray_vector; rayType = :line, triSide = 0, tolEps = 1e-3)
         @test isapprox(P,Point3{Float64}[[0.0, 0.0, -1.0], [0.0, 0.0, -1.0], 
                                          [0.0, 0.0,  1.0], [0.0, 0.0,  1.0]],atol=eps_level)
-        @test isa(indIntersect,Vector{Int64})
+        @test isa(indIntersect,Vector{Int})
     end
 end
 
@@ -3948,11 +3948,11 @@ end
     @testset "Cylinder" begin
         r = 25
         s = r/10
-        nc = round(Int64,(2*pi*r)/s)
+        nc = round(Int,(2*pi*r)/s)
         d = r*2
         Vc = circlepoints(r, nc; dir=:acw)
-        num_steps = round(Int64,d/s)
-        num_steps = num_steps + Int64(iseven(num_steps))
+        num_steps = round(Int,d/s)
+        num_steps = num_steps + Int(iseven(num_steps))
         F, V = extrudecurve(Vc; extent=d,  direction=:positive,  n=[0.0,0.0,1.0], num_steps=num_steps, close_loop=true, face_type=:quad)
         K1,K2,U1,U2,H,G = mesh_curvature_polynomial(F,V)
         @test isapprox(mean(K1),1.0/r,atol=tol_level)
@@ -3968,7 +3968,7 @@ end
     
     @testset "Single face" begin
         # Single triangle
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0]]
         Fn, Vn = separate_vertices(F, V)    
         @test Vn isa Vector{Point3{Float64}}
@@ -3977,7 +3977,7 @@ end
         @test length(Vn) == length(F)*length(F[1])
 
         # Single triangle, un-used nodes
-        F = TriangleFace{Int64}[[1,2,3]]
+        F = TriangleFace{Int}[[1,2,3]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0],
                             [1.0,0.0,0.0],[1.0,1.0,0.0]]
         Fn, Vn = separate_vertices(F, V)    
@@ -3987,7 +3987,7 @@ end
         @test length(Vn) == length(F)*length(F[1])
 
         # Single quad
-        F = QuadFace{Int64}[[1,2,3,4]]
+        F = QuadFace{Int}[[1,2,3,4]]
         V = Point3{Float64}[[0.0,0.0,0.0],[1.0,0.0,0.0],[1.0,1.0,0.0],[0.0,1.0,0.0]]
         Fn, Vn = separate_vertices(F, V)    
         @test Vn isa Vector{Point3{Float64}}
@@ -4139,13 +4139,13 @@ end
 
 @testset "invert_faces" begin
     # Single face
-    F = TriangleFace{Int64}[[1,2,3]]
-    F_inv = TriangleFace{Int64}[[3,2,1]]
+    F = TriangleFace{Int}[[1,2,3]]
+    F_inv = TriangleFace{Int}[[3,2,1]]
     @test invert_faces(F)==F_inv
 
     # Two face
-    F = [TriangleFace{Int64}(1, 2, 3),TriangleFace{Int64}(4, 5, 6)]   
-    F_inv = [TriangleFace{Int64}(3, 2, 1),TriangleFace{Int64}(6, 5, 4)]   
+    F = [TriangleFace{Int}(1, 2, 3),TriangleFace{Int}(4, 5, 6)]   
+    F_inv = [TriangleFace{Int}(3, 2, 1),TriangleFace{Int}(6, 5, 4)]   
     @test invert_faces(F)==F_inv    
 end
 
@@ -4193,7 +4193,7 @@ end
         Fr,Vr = sweeploft(Vc,reverse(V1),reverse(V2); face_type=:quad, num_twist=0, close_loop=true)
 
         @test F == Fr
-        @test isa(F,Vector{QuadFace{Int64}})
+        @test isa(F,Vector{QuadFace{Int}})
         @test length(Vr) == nc*np
         @test length(Vr) == length(V)
         @test isa(V,Vector{Point3{Float64}})  
@@ -4202,13 +4202,13 @@ end
     @testset "quad" begin
         F,V = sweeploft(Vc,V1,V2; face_type=:quad, num_twist=0, close_loop=true)
         @test length(F) == (nc-1)*np
-        @test isa(F,Vector{QuadFace{Int64}})
+        @test isa(F,Vector{QuadFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})
 
         F,V = sweeploft(Vc,V1,V2; face_type=:quad, num_twist=1, close_loop=false)
         @test length(F) == (nc-1)*(np-1)
-        @test isa(F,Vector{QuadFace{Int64}})
+        @test isa(F,Vector{QuadFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})        
     end
@@ -4216,13 +4216,13 @@ end
     @testset "tri_slash" begin
         F,V = sweeploft(Vc,V1,V2; face_type=:tri_slash, num_twist=0, close_loop=true)
         @test length(F) == (nc-1)*np*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})
 
         F,V = sweeploft(Vc,V1,V2; face_type=:tri_slash, num_twist=1, close_loop=false)
         @test length(F) == (nc-1)*(np-1)*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})        
     end
@@ -4230,13 +4230,13 @@ end
     @testset "tri" begin
         F,V = sweeploft(Vc,V1,V2; face_type=:tri, num_twist=0, close_loop=true)
         @test length(F) == (nc-1)*np*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})
 
         F,V = sweeploft(Vc,V1,V2; face_type=:tri, num_twist=1, close_loop=false)
         @test length(F) == (nc-1)*(np-1)*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})        
     end
@@ -4244,13 +4244,13 @@ end
     @testset "quad2tri" begin
         F,V = sweeploft(Vc,V1,V2; face_type=:quad2tri, num_twist=0, close_loop=true)
         @test length(F) == (nc-1)*np*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})
 
         F,V = sweeploft(Vc,V1,V2; face_type=:quad2tri, num_twist=1, close_loop=false)
         @test length(F) == (nc-1)*(np-1)*2
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test length(V) == nc*np
         @test isa(V,Vector{Point3{Float64}})        
     end
@@ -4280,7 +4280,7 @@ end
     num_steps = 6
     close_loop = false
 
-    ind = round.(Int64,range(1,nc*num_steps,5))
+    ind = round.(Int,range(1,nc*num_steps,5))
 
     θ = 1.0*π
 
@@ -4325,7 +4325,7 @@ end
         face_type =:quad
         close_loop = true
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=n,num_steps=nothing,close_loop=close_loop,face_type=face_type)
-        @test length(V)/nc == ceil(Int64,(2*θ)/pointspacingmean(Vc))
+        @test length(V)/nc == ceil(Int,(2*θ)/pointspacingmean(Vc))
     end
 
     m = [-0.7838430424199713, 0.08108629344330351, -0.6156420208736807]
@@ -4334,7 +4334,7 @@ end
         close_loop = true
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == nc*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4346,7 +4346,7 @@ end
         close_loop = false
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{QuadFace{Int64}}
+        @test F isa Vector{QuadFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4360,7 +4360,7 @@ end
         close_loop = true
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4372,7 +4372,7 @@ end
         close_loop = false
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4386,7 +4386,7 @@ end
         close_loop = true
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4398,7 +4398,7 @@ end
         close_loop = false
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4412,7 +4412,7 @@ end
         close_loop = true
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == nc*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4424,7 +4424,7 @@ end
         close_loop = false
         F,V = revolvecurve(Vc; extent=θ,  direction=:positive, n=m,num_steps=num_steps,close_loop=close_loop,face_type=face_type)
 
-        @test F isa Vector{TriangleFace{Int64}}
+        @test F isa Vector{TriangleFace{Int}}
         @test length(F) == (nc-1)*(num_steps-1)*2
         @test V isa Vector{Point3{Float64}}
         @test length(V) == nc*num_steps
@@ -4446,7 +4446,7 @@ end
 
     n = 50 # Number of points, first testing an even number
     V = batman(n)
-    ind = round.(Int64,range(1,length(V),5))
+    ind = round.(Int,range(1,length(V),5))
 
     @test length(V) == n # Correct length
     @test isa(V,Vector{Point{3,Float64}}) # Correct type
@@ -4488,14 +4488,14 @@ end
     # Test for unrefined hexagon triangulation 
     n = 0 
     F,V = tridisc(r,n)
-    @test isa(F,Vector{TriangleFace{Int64}})
+    @test isa(F,Vector{TriangleFace{Int}})
     @test isa(V,Vector{Point{3,Float64}})
     @test length(V) == 7
     @test isapprox(maximum(norm.(V)),r,atol=eps_level)
 
     # Test for defaults    
     F,V = tridisc()
-    @test isa(F,Vector{TriangleFace{Int64}})
+    @test isa(F,Vector{TriangleFace{Int}})
     @test isa(V,Vector{Point{3,Float64}})
     @test length(V) == 7
     @test isapprox(maximum(norm.(V)),1.0,atol=eps_level)
@@ -4503,7 +4503,7 @@ end
     # Test for refined hexagon triangulation 
     n = 1 
     F,V = tridisc(r,n)
-    @test isa(F,Vector{TriangleFace{Int64}})
+    @test isa(F,Vector{TriangleFace{Int}})
     @test isa(V,Vector{Point{3,Float64}})
     @test length(V) == 19
     @test isapprox(maximum(norm.(V)),r,atol=eps_level)
@@ -4541,7 +4541,7 @@ end
 
     F,V,C = regiontrimesh(VT,R,P)
 
-    @test isa(F,Vector{TriangleFace{Int64}})
+    @test isa(F,Vector{TriangleFace{Int}})
     @test isa(V,Vector{Point{3,Float64}})
     @test isa(C,Vector{Float64})
     @test length(F) == length(C) # Color length matches faces
@@ -4556,7 +4556,7 @@ end
     R = ([1],)
     P = (pointSpacing)
     F,V,C = regiontrimesh(VT,R,P)
-    @test isa(F,Vector{TriangleFace{Int64}})
+    @test isa(F,Vector{TriangleFace{Int}})
     @test isa(V,Vector{Point{3,Float64}})
     @test isa(C,Vector{Float64})
     @test length(F) == length(C)
@@ -4821,7 +4821,7 @@ end
         Eb = boundaryedges(F)
 
         Fs,Fsq,Vs = dualclad(F,V,0.5; connectivity=:face)
-        ind = round.(Int64,range(1,length(Vs),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vs),6)) # Sample indices
 
         @test length(Fs) == length(F)
         @test length(Fsq) == length(E)
@@ -4833,7 +4833,7 @@ end
 
 
         Fs,Fsq,Vs = dualclad(F,V,0.5; connectivity=:edge)
-        ind = round.(Int64,range(1,length(Vs),6)) # Sample indices
+        ind = round.(Int,range(1,length(Vs),6)) # Sample indices
 
         @test length(Fs) == length(F)
         @test length(Fsq) == length(F)*length(F[1])
@@ -4851,7 +4851,7 @@ end
 @testset "tet2hex" verbose=true begin
     eps_level = 1e-6
 
-    E = [Tet4{Int64}(1,2,3,4),Tet4{Int64}(2,3,4,5),Tet4{Int64}(6,7,8,9)]
+    E = [Tet4{Int}(1,2,3,4),Tet4{Int}(2,3,4,5),Tet4{Int}(6,7,8,9)]
     V = [Point{3,Float64}(-1.0,0.0,0.0),
          Point{3,Float64}( 1.0,0.0,0.0),
          Point{3,Float64}( 0.0,1.0,0.0),
@@ -4864,7 +4864,7 @@ end
          ]
          
     Eh,Vh = tet2hex(E,V)
-    ind = round.(Int64,range(1,length(Vh),10))
+    ind = round.(Int,range(1,length(Vh),10))
 
    
     @test length(Eh) == length(E)*4
@@ -4873,7 +4873,7 @@ end
     [3.3333333333333335, 0.5, 0.3333333333333333], [-0.5, 0.5, 0.0], [1.0, 0.5, 0.5], 
     [3.5, 0.5, 0.0], [3.0, 0.75, 0.5]],atol=eps_level)
 
-    @test isa(Eh,Vector{Hex8{Int64}})
+    @test isa(Eh,Vector{Hex8{Int}})
     @test isa(Vh,Vector{eltype(V)})
 
 end
@@ -4886,7 +4886,7 @@ end
         E,V,F,Fb,CFb_type = hexbox(boxDim,boxEl)
         F = element2faces(E)
         @test length(F) == length(E)*6
-        @test isa(F,Vector{QuadFace{Int64}})
+        @test isa(F,Vector{QuadFace{Int}})
         @test F[1] == [3,4,2,1]
 
         boxDim = [1.0,2.0,3.0] # Dimensions for the box in each direction
@@ -4894,46 +4894,46 @@ end
         E,V,F,Fb,CFb_type = hexbox(boxDim,boxEl)
         F = element2faces(E)
         @test length(F) == length(E)*6
-        @test isa(F,Vector{QuadFace{Int64}})
+        @test isa(F,Vector{QuadFace{Int}})
         @test F[1] == [3,4,2,1]
     end
 
     @testset "tetrahedra" begin
-        E = [Tet4{Int64}(1,2,3,4)]
+        E = [Tet4{Int}(1,2,3,4)]
         F = element2faces(E)
         @test length(F) == length(E)*4
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test F[1] == [3,2,1]
 
-        E = [Tet4{Int64}(1,2,3,4),Tet4{Int64}(2,3,4,5),Tet4{Int64}(6,7,8,9)]
+        E = [Tet4{Int}(1,2,3,4),Tet4{Int}(2,3,4,5),Tet4{Int}(6,7,8,9)]
         F = element2faces(E)
         @test length(F) == length(E)*4
-        @test isa(F,Vector{TriangleFace{Int64}})
+        @test isa(F,Vector{TriangleFace{Int}})
         @test F[1] == [3,2,1]
     end
 
     @testset "pentahedra" begin
-        E = [Penta6{Int64}(1,2,3,4,5,6)]
+        E = [Penta6{Int}(1,2,3,4,5,6)]
         F = element2faces(E)
         @test isa(F,Tuple)
         @test length(F[1]) == length(E)*2
         @test length(F[2]) == length(E)*3
-        @test isa(F[1],Vector{TriangleFace{Int64}})
-        @test isa(F[2],Vector{QuadFace{Int64}})
+        @test isa(F[1],Vector{TriangleFace{Int}})
+        @test isa(F[2],Vector{QuadFace{Int}})
         @test F[1][1] == [3,2,1]
 
-        E = [Penta6{Int64}(1,2,3,4,5,6),Penta6{Int64}(1,2,3,7,8,9),Penta6{Int64}(7,8,9,4,5,6)]
+        E = [Penta6{Int}(1,2,3,4,5,6),Penta6{Int}(1,2,3,7,8,9),Penta6{Int}(7,8,9,4,5,6)]
         F = element2faces(E)
         @test isa(F,Tuple)
         @test length(F[1]) == length(E)*2
         @test length(F[2]) == length(E)*3
-        @test isa(F[1],Vector{TriangleFace{Int64}})
-        @test isa(F[2],Vector{QuadFace{Int64}})
+        @test isa(F[1],Vector{TriangleFace{Int}})
+        @test isa(F[2],Vector{QuadFace{Int}})
         @test F[1][1] == [3,2,1]
     end
 
     @testset "errors" begin
-        E = [Tet10{Int64}(1,2,3,4,5,6,7,8,9,10)]                
+        E = [Tet10{Int}(1,2,3,4,5,6,7,8,9,10)]                
         @test_throws Exception element2faces(E)
     end
 
@@ -4964,7 +4964,7 @@ end
 
     Eh0,Vh0 = subhex(E,V,2;direction=0)
     @test length(Eh0) == length(E)*8*8
-    @test isa(Eh0,Vector{Hex8{Int64}})
+    @test isa(Eh0,Vector{Hex8{Int}})
     @test isa(Vh0,Vector{eltype(V)})
 
     # Check when n=0 (no refinement)
@@ -4987,7 +4987,7 @@ end
     [-1.0, -0.0, 0.0], [0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -0.0, -1.0], 
     [0.0, -0.0, 1.0]]
 
-    @test F == QuadFace{Int64}[[1, 10, 5, 9], [2, 11, 6, 10], [3, 12, 7, 11], [4, 9, 8, 12], 
+    @test F == QuadFace{Int}[[1, 10, 5, 9], [2, 11, 6, 10], [3, 12, 7, 11], [4, 9, 8, 12], 
     [5, 10, 6, 14], [6, 11, 7, 14], [7, 12, 8, 14], [8, 9, 5, 14], [1, 13, 2, 10], [2, 13, 3, 11], 
     [3, 13, 4, 12], [4, 13, 1, 9]]
 
@@ -5005,14 +5005,14 @@ end
 
     @testset "tri2quad, split" verbose=true begin
         @testset "Single triangle" begin
-            F = [TriangleFace{Int64}(1,2,3)]
+            F = [TriangleFace{Int}(1,2,3)]
             V = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(1.0,1.0,0.0)]
             
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:split)
             @test length(Fq) == length(F)*3
             @test length(Vq) == length(V)+length(F)+length(E)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq,Point{3, Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], 
             [0.6666666666666666, 0.3333333333333333, 0.0], [0.5, 0.0, 0.0], [1.0, 0.5, 0.0], 
@@ -5028,11 +5028,11 @@ end
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:split)
 
-            ind = round.(Int64,range(1,length(Vq),6))
+            ind = round.(Int,range(1,length(Vq),6))
 
             @test length(Fq) == length(F)*3
             @test length(Vq) == length(V)+length(F)+length(E)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq[ind],Point{3, Float64}[[-0.8164965809277261, -0.47140452079103173, -0.3333333333333333], 
             [0.0, 0.9428090415820635, -0.3333333333333333], [0.0, 0.0, -0.3333333333333333], 
@@ -5049,11 +5049,11 @@ end
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:split)
 
-            ind = round.(Int64,range(1,length(Vq),6))
+            ind = round.(Int,range(1,length(Vq),6))
 
             @test length(Fq) == length(F)*3
             @test length(Vq) == length(V)+length(F)+length(E)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq[ind],Point{3, Float64}[[0.0, -0.5257311121191336, -0.85065080835204], 
             [-0.28355026945068, 0.0, -0.7423442429410713], [0.4587939734903912, -0.4587939734903912, 0.4587939734903912], 
@@ -5064,21 +5064,21 @@ end
 
     @testset "tri2quad, rhombic" verbose=true begin
         @testset "Single triangle" begin
-            F = [TriangleFace{Int64}(1,2,3)]
+            F = [TriangleFace{Int}(1,2,3)]
             V = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(1.0,1.0,0.0)]
             
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:rhombic)
             @test isempty(Fq)
             @test length(Vq) == length(V)+length(F)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq,Point{3, Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], 
             [1.0, 1.0, 0.0], [0.0, 0.0, 0.0]],atol=eps_level)
         end
         
         @testset "Single triangle, refined once" begin
-            F = [TriangleFace{Int64}(1,2,3)]
+            F = [TriangleFace{Int}(1,2,3)]
             V = [Point{3,Float64}(0.0,0.0,0.0),Point{3,Float64}(1.0,0.0,0.0),Point{3,Float64}(1.0,1.0,0.0)]
             F,V = subtri(F,V,1)
 
@@ -5086,7 +5086,7 @@ end
             Fq,Vq = tri2quad(F,V; method=:rhombic)
             @test length(Fq) == 3
             @test length(Vq) == length(V)+length(F)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq,Point{3, Float64}[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], 
             [1.0, 1.0, 0.0], [0.5, 0.0, 0.0], [1.0, 0.5, 0.0], [0.5, 0.5, 0.0], 
@@ -5103,11 +5103,11 @@ end
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:rhombic)
 
-            ind = round.(Int64,range(1,length(Vq),6))
+            ind = round.(Int,range(1,length(Vq),6))
 
             @test length(Fq) == length(E)
             @test length(Vq) == length(V)+length(F)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq,Point{3, Float64}[[-0.8164965809277261, -0.47140452079103173, -0.3333333333333333], 
             [0.8164965809277261, -0.47140452079103173, -0.3333333333333333], 
@@ -5126,11 +5126,11 @@ end
             E = meshedges(F; unique_only=true)
             Fq,Vq = tri2quad(F,V; method=:rhombic)
 
-            ind = round.(Int64,range(1,length(Vq),6))
+            ind = round.(Int,range(1,length(Vq),6))
 
             @test length(Fq) == length(E)
             @test length(Vq) == length(V)+length(F)
-            @test isa(Fq,Vector{QuadFace{Int64}})
+            @test isa(Fq,Vector{QuadFace{Int}})
             @test isa(Vq,typeof(V))
             @test isapprox(Vq[ind],Point{3, Float64}[[0.0, -0.5257311121191336, -0.85065080835204], 
             [0.5257311121191336, 0.85065080835204, 0.0], [-0.28355026945068, 0.0, -0.7423442429410713], 
@@ -5278,7 +5278,7 @@ end
     eps_level = 1e-6
 
     @testset "Vector with single QuadFace" begin        
-        F = QuadFace{Int64}[ [1,2,3,4] ]
+        F = QuadFace{Int}[ [1,2,3,4] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [0.0,1.0,0.0] ]
 
         d = 2.0
@@ -5287,15 +5287,15 @@ end
         for direction in directionSet
             E, VE = extrudefaces(F,V; extent=d, direction=direction, num_steps=num_steps)
             E_ind = reduce(vcat,E)            
-            @test isa(E, Vector{Hex8{Int64}})
+            @test isa(E, Vector{Hex8{Int}})
             @test isa(VE, Vector{eltype(V)})
             @test length(VE) == num_steps * length(V)
             @test length(E) == (num_steps-1) * length(F)
             @test minimum(E_ind) == 1
             @test maximum(E_ind) == length(VE)
-            @test E == Hex8{Int64}[[1, 2, 3, 4, 5, 6, 7, 8], [5, 6, 7, 8, 9, 10, 11, 12], [9, 10, 11, 12, 13, 14, 15, 16]]
+            @test E == Hex8{Int}[[1, 2, 3, 4, 5, 6, 7, 8], [5, 6, 7, 8, 9, 10, 11, 12], [9, 10, 11, 12, 13, 14, 15, 16]]
         end
-        ind = round.(Int64,range(1,length(VE),6))
+        ind = round.(Int,range(1,length(VE),6))
         E, VE = extrudefaces(F,V; extent=d, direction=:positive, num_steps=num_steps)
         @test isapprox(VE[ind],Point{3, Float64}[[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], 
         [1.0, 1.0, 0.6666666666666666], [1.0, 0.0, 1.3333333333333333], 
@@ -5303,7 +5303,7 @@ end
     end
     
     @testset "Vector of QuadFaces" begin        
-        F = QuadFace{Int64}[ [1,2,3,4], [5,6,3,2] ]
+        F = QuadFace{Int}[ [1,2,3,4], [5,6,3,2] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [0.0,1.0,0.0], [2.0,0.0,0.0], [2.0,1.0,0.0] ]
 
         d =  2.0
@@ -5312,17 +5312,17 @@ end
         for direction in directionSet
             E, VE = extrudefaces(F,V; extent=d, direction=direction, num_steps=num_steps)
             E_ind = reduce(vcat,E)            
-            @test isa(E, Vector{Hex8{Int64}})
+            @test isa(E, Vector{Hex8{Int}})
             @test isa(VE, Vector{eltype(V)})
             @test length(VE) == num_steps * length(V)
             @test length(E) == (num_steps-1) * length(F)
             @test minimum(E_ind) == 1
             @test maximum(E_ind) == length(VE)
-            @test E == Hex8{Int64}[[1, 2, 3, 4, 7, 8, 9, 10], [5, 6, 3, 2, 11, 12, 9, 8], 
+            @test E == Hex8{Int}[[1, 2, 3, 4, 7, 8, 9, 10], [5, 6, 3, 2, 11, 12, 9, 8], 
             [7, 8, 9, 10, 13, 14, 15, 16], [11, 12, 9, 8, 17, 18, 15, 14], 
             [13, 14, 15, 16, 19, 20, 21, 22], [17, 18, 15, 14, 23, 24, 21, 20]]
         end
-        ind = round.(Int64,range(1,length(VE),6))
+        ind = round.(Int,range(1,length(VE),6))
         E, VE = extrudefaces(F,V; extent=d, direction=:positive, num_steps=num_steps)
         @test isapprox(VE[ind],Point{3, Float64}[[0.0, 0.0, 0.0], [2.0, 1.0, 0.0], 
         [0.0, 1.0, 0.6666666666666666], [1.0, 1.0, 1.3333333333333333], 
@@ -5356,7 +5356,7 @@ end
     end
 
     @testset "Vector of TriangeFaces" begin       
-        F = TriangleFace{Int64}[ [1,2,3], [2,4,3] ]
+        F = TriangleFace{Int}[ [1,2,3], [2,4,3] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [2.0,0.0,0.0]]
 
         d = 2.0
@@ -5365,17 +5365,17 @@ end
         for direction in directionSet
             E, VE = extrudefaces(F,V; extent=d, direction=direction, num_steps=num_steps)
             E_ind = reduce(vcat,E)
-            @test isa(E, Vector{Penta6{Int64}})
+            @test isa(E, Vector{Penta6{Int}})
             @test isa(VE, Vector{eltype(V)})
             @test length(VE) == num_steps * length(V)
             @test length(E) == (num_steps-1) * length(F)
             @test minimum(E_ind) == 1
             @test maximum(E_ind) == length(VE)
-            @test E == Penta6{Int64}[[1, 2, 3, 5, 6, 7], [2, 4, 3, 6, 8, 7], 
+            @test E == Penta6{Int}[[1, 2, 3, 5, 6, 7], [2, 4, 3, 6, 8, 7], 
             [5, 6, 7, 9, 10, 11], [6, 8, 7, 10, 12, 11], [9, 10, 11, 13, 14, 15], 
             [10, 12, 11, 14, 16, 15]]
         end
-        ind = round.(Int64,range(1,length(VE),6))
+        ind = round.(Int,range(1,length(VE),6))
         E, VE = extrudefaces(F,V; extent=d, direction=:positive, num_steps=num_steps)
         @test isapprox(VE[ind],Point{3, Float64}[[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], 
         [1.0, 1.0, 0.6666666666666666], [1.0, 0.0, 1.3333333333333333], 
@@ -5383,7 +5383,7 @@ end
     end
 
     @testset "errors" begin
-        F = TriangleFace{Int64}[ [1,2,3], [2,4,3] ]
+        F = TriangleFace{Int}[ [1,2,3], [2,4,3] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [2.0,0.0,0.0]]
 
         d = 2.0
@@ -5398,7 +5398,7 @@ end
 
         d = 2.0
         num_steps = 5        
-        F = LineFace{Int64}[ [1,2], [3,4] ]
+        F = LineFace{Int}[ [1,2], [3,4] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [2.0,0.0,0.0]]
         @test_throws Exception extrudefaces(F,V; extent=d, direction=:positive, num_steps=num_steps)        
     end


### PR DESCRIPTION
Your code probably won't work on 32-bit architectures since you're using `Int64` everywhere. As documented [here](https://docs.julialang.org/en/v1/manual/integers-and-floating-point-numbers/#Integers), `Int` is an alias that stands for `Int64` on 64-bit systems and `Int32` on 32-bit systems (so on 64-bit systems, this PR does nothing as `Int === Int64`).

The changes were made by just doing a find-replace across the whole package.