### PR TITLE
Use DelaunayTriangulation's public API

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -3884,7 +3884,7 @@ function regiontrimesh(VT,R,P)
         # Initial triangulation 
         constrained_segments_ori = deepcopy(constrained_segments) # Clone since triangulate can add new constraint points
         TRn = triangulate(Vn; boundary_nodes=constrained_segments, delete_ghosts=true)
-        Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
+        Fn = [TriangleFace{Int64}(tr) for tr in each_solid_triangle(TRn)] 
 
         # Check if new boundary points were introduced and remove if needed 
         Eb = boundaryedges(Fn)
@@ -3899,8 +3899,8 @@ function regiontrimesh(VT,R,P)
             Vn = Vn[indKeep]
             constrained_segments = [[indFix[c[1]]] for c in constrained_segments_ori] # Fix indices after point removal                
             TRn = triangulate(Vn; boundary_nodes=constrained_segments,delete_ghosts=true)
-            Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
-            Vn = TRn.points
+            Fn = [TriangleFace{Int64}(tr) for tr in each_solid_triangle(TRn)] 
+            Vn = get_points(TRn)
         end
 
         # Remove unused points (e.g. outside region)
@@ -3928,8 +3928,8 @@ function regiontrimesh(VT,R,P)
 
         # Redo triangulation after points have been removed
         TRn = triangulate(Vn; boundary_nodes=constrained_segments,delete_ghosts=true)
-        Fn = [TriangleFace{Int64}(tr) for tr in TRn.triangles] 
-        Vn = TRn.points
+        Fn = [TriangleFace{Int64}(tr) for tr in each_solid_triangle(TRn)] 
+        Vn = get_points(TRn)
 
         Fn,Vn,indFix = remove_unused_vertices(Fn,Vn)
 


### PR DESCRIPTION
The API for accessing triangles and points is `each_solid_triangle` (technically `get_triangles` or `each_triangle` works as you are not using ghost triangles, but the intention is that for iteration you use `each_solid_triangle`) and `get_points`, respectively.  

There are some other areas you could simply your use of `TRn` e.g. `boundaryedges` could just look at `DelaunayTriangulation.each_boundary_edge`, (which is an unordered iterator, but there is another method for getting order if that's needed..) but I just happened to note these easy changes.