### PR TITLE
manage import(s) and using(s) as only the required objects are imported

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Comodo"
 uuid = "59095408-2761-4f7a-bdc2-044e78630271"
-authors = ["Kevin-Mattheus-Moerman <kevin.moerman@gmail.com>"]
 version = "0.1.0"
+authors = ["Kevin-Mattheus-Moerman <kevin.moerman@gmail.com>"]
 
 [deps]
 BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
@@ -10,7 +10,6 @@ DelaunayTriangulation = "927a84f5-c5f4-47a5-9785-b46e178433df"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MarchingCubes = "299715c1-40a9-479a-aaf9-4a633d36f717"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
@@ -26,7 +25,6 @@ DelaunayTriangulation = "1.6.3"
 Distances = "0.10"
 GLMakie = "0.10.18"
 GeometryBasics = "0.3, 0.4"
-Interpolations = "0.15"
 LinearAlgebra = "1.10.7, 1.11.0"
 MarchingCubes = "0.1.11"
 QuadGK = "2.9"

--- a/src/Comodo.jl
+++ b/src/Comodo.jl
@@ -1,20 +1,22 @@
 module Comodo
 
-# Import dependancy libraries
-import GeometryBasics
-import LinearAlgebra
-import DataStructures
-import Rotations
-import Statistics
-import GLMakie
-import Interpolations # E.g. for resampling curves
-import BSplineKit
-import QuadGK
-import Distances
-import DelaunayTriangulation # For regiontrimesh
-import StaticArrays # For volumetric mesh definitions
-import TetGen # For tetrahedral meshing
+# Import required functions and modules from dependancy libraries
+using Statistics: mean, Statistics
+using Distances: euclidean, Distances
+using QuadGK: quadgk, QuadGK
+using StaticArrays: StaticVector, Size, StaticArrays
+using Rotations: RotMatrix3, RotXYZ, rotation_between, AngleAxis, Rotations
+using DataStructures: OrderedDict, DataStructures
 import MarchingCubes # For isosurface creation
+using TetGen: tetrahedralize, TetGen
+using BSplineKit: BSplineOrder, BSplineKit
+using DelaunayTriangulation: triangulate, each_solid_triangle, get_points, DelaunayTriangulation
+using GLMakie: Slider, Axis3, Figure, LScene, Keyboard, events, record, set_close_to!, wireframe!, GLMakie
+using LinearAlgebra: cross, norm, dot, eigen, svd, det, LinearAlgebra
+using GeometryBasics: LineFace, Point, NgonFace, 
+                      OffsetInteger, AbstractPoint, Vec, 
+                      QuadFace, TriangleFace, faces, 
+											PointMeta, coordinates, Vec3, GeometryBasics
 
 include("functions.jl")
 

--- a/src/Comodo.jl
+++ b/src/Comodo.jl
@@ -20,8 +20,21 @@ using GeometryBasics: LineFace, Point, NgonFace,
 
 include("functions.jl")
 
-# Export imported packages
+# Export imported modules for later possible use
 export GeometryBasics
+export Statistics
+export Distances
+export QuadGK
+export StaticArrays
+export Rotations
+export MarchingCubes
+export TetGen
+export BSplineKit
+export DelaunayTriangulation
+export GLMakie
+export LinearAlgebra
+export GeometryBasics
+export DataStructures
 
 # Export types
 export Element, Tet4, Tet10, Hex8, Hex20, Penta6, Rhombicdodeca14, Truncatedocta24 # Volumetric elements (polyhedra)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,23 +1,9 @@
-# Call required packages
-
-using GeometryBasics # For point and mesh format
-using LinearAlgebra # For things like dot and cross products
-using DataStructures # For unique_dict
-using Statistics # For: mean etc.
-using GLMakie # For slidercontrol
-using Rotations 
-using Interpolations # E.g. for resampling curves
-using BSplineKit # E.g. for resampling curves
-using QuadGK: quadgk # For numerical integration
-using Distances
-using DelaunayTriangulation # For triangular meshing
-using StaticArrays
-using TetGen # For tetrahedral meshing in tetgenmesh
-using MarchingCubes # For isosurface creation
 
 # Define types
 abstract type AbstractElement{N,T} <: StaticVector{N,T} end
+
 GeometryBasics.@fixed_vector Element = AbstractElement
+
 const Tet4{T} = Element{4,T} where T<:Integer
 const Tet10{T} = Element{10,T} where T<:Integer
 const Hex8{T} = Element{8,T} where T<:Integer
@@ -85,7 +71,7 @@ function slidercontrol(hSlider::Slider,ax::Union{Axis3, Figure, LScene})
     sliderRange = hSlider.range[] # Get slider range
     rangeLength = length(sliderRange) # Number of possible steps 
     sliderIndex = hSlider.selected_index[] # Current slider index
-    on(events(ax).keyboardbutton) do event
+    GLMakie.on(events(ax).keyboardbutton) do event
         if event.action == Keyboard.press || event.action == Keyboard.repeat # Pressed or held for instance            
             if event.key == Keyboard.up                                                  
                 if sliderIndex == rangeLength
@@ -4028,7 +4014,7 @@ function kabsch_rot(V1::Vector{Point{ND,TV1}},V2::Vector{Point{ND,TV2}}) where N
     d = det(U)*det(V) #sign(det(U'*V))
     D = [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]
     D[3,3] = d 
-    return Rotations.RotMatrix3{Float64}(V*D*U')
+    return RotMatrix3{Float64}(V*D*U')
 end
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,3 @@
 [deps]
-BSplineKit = "093aae92-e908-43d7-9660-e50ee39d5a0a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,5 @@
 using Test, FileIO, Comodo, Comodo.GeometryBasics, Statistics, LinearAlgebra, GLMakie, Rotations, BSplineKit
 
-# ConnectivitySet
-
 @testset "comododir" begin
     f = comododir()
     @test any(contains.(readdir(f),"src"))
@@ -4624,7 +4622,6 @@ end
     end
 end
 
-
 @testset "revolvecurve" verbose = true begin
     eps_level = 1e-6
     nc = 5
@@ -4902,7 +4899,6 @@ end
     @test_throws Exception tridisc(r,n; ngon=6, method = :linear, orientation=:wrong) 
     
 end
-
 
 @testset "regiontrimesh" verbose = true begin  
     n1 = 120

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,10 @@
-using Test, FileIO, Comodo, Comodo.GeometryBasics, Statistics, LinearAlgebra, GLMakie, Rotations, BSplineKit
+using Test, FileIO, Comodo
+using Comodo.GeometryBasics
+using Comodo.Statistics
+using Comodo.LinearAlgebra
+using Comodo.GLMakie
+using Comodo.Rotations
+using Comodo.BSplineKit
 
 @testset "comododir" begin
     f = comododir()


### PR DESCRIPTION
- Remove unnecessary dependency: Interpolations
- `import Package: f, g, Package` style imports now only import the necessary objects as well as the module itself for fully-qualified usages like `Package.h(x)`. 
- I hope this fix enhances the compilation times and keeps the package environment more clean.
- Remove most of the dependencies that have already been exported in Test environment. Tests now import `Comodo.Package` instead of `Package` if the `Package` is already a dependency in Comodo. (I hope this will reduce the initial time before the tests run)
- Now Comodo exports packages that are already imported. Users can use already imported packages and their content when they are working with a Comodo instance (e.g. `using Comodo.GLMakie`). Note that a separate `GLMakie` instance can also be imported. 