### PR TITLE
add example_checker.jl for checking if examples are not broken

### DIFF
--- a/examples/demo_gridpoints.jl
+++ b/examples/demo_gridpoints.jl
@@ -1,5 +1,6 @@
 using Comodo
 using Comodo.GLMakie
+using Comodo.LinearAlgebra
 
 #=
 This demo shows the use of the gridpoints function. This function can be used to create

--- a/examples/demo_surface_mesh_smoothing.jl
+++ b/examples/demo_surface_mesh_smoothing.jl
@@ -1,6 +1,7 @@
 using Comodo
 using Comodo.GLMakie
 using Comodo.GeometryBasics
+using Comodo.Statistics
 using FileIO, Random
 
 Random.seed!(1) # Set seed so demo performs the same each time

--- a/examples/demo_vertexnormal.jl
+++ b/examples/demo_vertexnormal.jl
@@ -1,6 +1,7 @@
 using Comodo
 using Comodo.GLMakie
 using Comodo.GeometryBasics
+using Comodo.Statistics
 using FileIO
 
 #=

--- a/examples/example_checker.jl
+++ b/examples/example_checker.jl
@@ -1,0 +1,53 @@
+module ExampleCheckter
+
+using Pkg
+Pkg.activate("../.")
+
+using Test
+
+struct Problem
+    filename::String
+    error::Exception
+end
+
+function Base.show(io::IO, p::Problem)
+    println(io, "Problem in file: $(p.filename)")
+    println(io, "Error: $(p.error)")
+end
+
+function load_and_run!(filename::String, problems::Vector{Problem})::Bool
+    try
+        @test begin
+            include(filename)
+            return true
+        end
+    catch e
+        p = Problem(filename, e)
+        push!(problems, p)
+        println("Error in file: $filename")
+        println("Please check the error message to find out the required function and package")
+        println(e)
+        return false
+    end
+end
+
+function main()
+    dircontent = readdir(".")
+    juliafiles = filter(x -> occursin(r"demo.*\.jl", x), dircontent)
+
+    problems = Vector{Problem}(undef, 0)
+
+    for file in juliafiles
+        println("Checking file: $file")
+        load_and_run!(file, problems)
+    end
+
+    display(problems)
+end
+
+function __init__()
+    @info "Module initialized, running main"
+    main()
+end
+
+end # end of module

--- a/examples/example_checker.jl
+++ b/examples/example_checker.jl
@@ -1,4 +1,4 @@
-module ExampleCheckter
+module ExampleChecker
 
 function load_and_run!(filename::String, problems::Vector{String})::Bool
     cmdline = "using Pkg; Pkg.activate(\"./..\"); include(\"$filename\")"

--- a/examples/example_checker.jl
+++ b/examples/example_checker.jl
@@ -1,10 +1,5 @@
 module ExampleCheckter
 
-using Pkg
-Pkg.activate("../.")
-
-using Test
-
 function load_and_run!(filename::String, problems::Vector{String})::Bool
     cmdline = "using Pkg; Pkg.activate(\"./..\"); include(\"$filename\")"
     command = `julia -e $cmdline`


### PR DESCRIPTION
Checks all of the demo files and run them. Reports the broken ones.

### Usage:

```shell
> cd examples
> julia example_checker.jl
```

Current output:


```julia
2-element Vector{Main.ExampleCheckter.Problem}:
 Problem in file: demo_donut.jl
Error: Test.FallbackTestSetException("There was an error during testing")

 Problem in file: demo_extrudefaces.jl
Error: Test.FallbackTestSetException("There was an error during testing")
```


As it is seen, we have two problematic demo files. We can manually run them to see the problems or examine the output given by the `example_checker.jl`