### PR TITLE
fix typos in documentation and code comments as well as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Comodo is a [Julia](https://julialang.org/) package for **computational (bio)mec
 
 Loosely Comodo could stand for **Com**putational **Mo**delling for **D**esign **O**ptimization. A more philosophical angle would be to say that **DO** is like *-do* in the Japanese art *Judo* (ju=柔=gentle, do=道=way), so in this sense Comodo stands for *"the way of computational modelling"*. Comodo is perhaps best defined by its scope. Comodo aims to be a "one-stop-shop" for researchers in computational (bio)mechanics and computational design. It will feature tools for geometry processing, meshing, automated design / topology optimization, finite element analysis, as well as (e.g. medical) image processing and segmentation. 
 
-Comodo.jl started out as a modern re-implementation in Julia of the MATLAB toolbox [GIBBON](https://github.com/gibbonCode/GIBBON). However, rather than literally porting each functional unit, it instead aims to follow a similar philosophy and cover similar but more advanced core functionaly.
+Comodo.jl started out as a modern re-implementation in Julia of the MATLAB toolbox [GIBBON](https://github.com/gibbonCode/GIBBON). However, rather than literally porting each functional unit, it instead aims to follow a similar philosophy and cover similar but more advanced core functionality.
 
 # Installation
 ```julia
@@ -46,7 +46,7 @@ New functionality to add:
 - [ ] Surface stitching method
 
 # How to contribute? 
-Your help would be greatly appreciated! If you can contribute please do so by posting a pull-request. I am very much open to fully acknowledging your contributions e.g. by listing you as a contributor properly whereever possible, by welcoming you on board as a long term contributor, or by inviting you to be a co-author on publications featuring Comodo functionality. 
+Your help would be greatly appreciated! If you can contribute please do so by posting a pull-request. I am very much open to fully acknowledging your contributions e.g. by listing you as a contributor properly wherever possible, by welcoming you on board as a long term contributor, or by inviting you to be a co-author on publications featuring Comodo functionality. 
 
 # License 
 Comodo.jl is released open source under the [Apache 2.0 license](https://github.com/COMODO-research/Comodo.jl/blob/main/LICENSE).

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -155,15 +155,19 @@ version = "3.29.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "b10d0b65641d57b8b4d5e234446582de5047050d"
+git-tree-sha1 = "c7acce7a7e1078a20a285211dd73cd3941a871d6"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.5"
+version = "0.12.0"
+weakdeps = ["StyledStrings"]
+
+    [deps.ColorTypes.extensions]
+    StyledStringsExt = "StyledStrings"
 
 [[deps.ColorVectorSpace]]
 deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "Requires", "Statistics", "TensorCore"]
-git-tree-sha1 = "a1f44953f2382ebb937d60dafbe2deea4bd23249"
+git-tree-sha1 = "8b3b6f87ce8f65a2b4f857528fd8d70086cd72b1"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.10.0"
+version = "0.11.0"
 weakdeps = ["SpecialFunctions"]
 
     [deps.ColorVectorSpace.extensions]
@@ -188,7 +192,7 @@ version = "1.0.0"
 
 [[deps.Comodo]]
 deps = ["BSplineKit", "DataStructures", "DelaunayTriangulation", "Distances", "GLMakie", "GeometryBasics", "LinearAlgebra", "MarchingCubes", "QuadGK", "Rotations", "StaticArrays", "Statistics", "TetGen"]
-git-tree-sha1 = "30ce8fc5ab9f962b6d82a47f43414a6668e3cd58"
+git-tree-sha1 = "fb7f8cf993b8f03d1a48128dc198ddecd7b44c36"
 repo-rev = "main"
 repo-url = ".."
 uuid = "59095408-2761-4f7a-bdc2-044e78630271"
@@ -481,9 +485,9 @@ version = "3.4.0+2"
 
 [[deps.GLMakie]]
 deps = ["ColorTypes", "Colors", "FileIO", "FixedPointNumbers", "FreeTypeAbstraction", "GLFW", "GeometryBasics", "LinearAlgebra", "Makie", "Markdown", "MeshIO", "ModernGL", "Observables", "PrecompileTools", "Printf", "ShaderAbstractions", "StaticArrays"]
-git-tree-sha1 = "8753fba3356131357b5cd02500fe80c3668535d0"
+git-tree-sha1 = "14e1835ddc8453d4a8a75f6c26f206b983d39142"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.10.18"
+version = "0.11.3"
 
 [[deps.GeoFormatTypes]]
 git-tree-sha1 = "8e233d5167e63d708d41f87597433f59a0f213fe"
@@ -497,10 +501,10 @@ uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 version = "1.4.1"
 
 [[deps.GeometryBasics]]
-deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "b62f2b2d76cee0d61a2ef2b3118cd2a3215d3134"
+deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
+git-tree-sha1 = "f08692959aa8346272de501d1ddfbc8ea0ab0d31"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.4.11"
+version = "0.5.6"
 
 [[deps.Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -623,9 +627,9 @@ weakdeps = ["Unitful"]
 
 [[deps.IntervalArithmetic]]
 deps = ["CRlibm_jll", "LinearAlgebra", "MacroTools", "OpenBLASConsistentFPCSR_jll", "RoundingEmulator"]
-git-tree-sha1 = "7b3603d3a5c52bcb18de8e46fa62e4176055f31e"
+git-tree-sha1 = "dfbf101df925acf1caa3b15a00b574887cd8472d"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
-version = "0.22.25"
+version = "0.22.26"
 
     [deps.IntervalArithmetic.extensions]
     IntervalArithmeticDiffRulesExt = "DiffRules"
@@ -868,16 +872,16 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.15"
 
 [[deps.Makie]]
-deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
-git-tree-sha1 = "be3051d08b78206fb5e688e8d70c9e84d0264117"
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "PNGFiles", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "e64b545d25e05a609521bfc36724baa072bfd31a"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.21.18"
+version = "0.22.2"
 
 [[deps.MakieCore]]
 deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
-git-tree-sha1 = "9019b391d7d086e841cbeadc13511224bd029ab3"
+git-tree-sha1 = "605d6e8f2b7eba7f5bc6a16d297475075d5ea775"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.8.12"
+version = "0.9.1"
 
 [[deps.MappedArrays]]
 git-tree-sha1 = "2dab0221fe2b0f2cb6754eaa743cc266339f527e"
@@ -908,9 +912,9 @@ version = "2.28.6+0"
 
 [[deps.MeshIO]]
 deps = ["ColorTypes", "FileIO", "GeometryBasics", "Printf"]
-git-tree-sha1 = "14a12d9153b1a1a22d669eede58b2ea2164ff138"
+git-tree-sha1 = "c009236e222df68e554c7ce5c720e4a33cc0c23f"
 uuid = "7269a6da-0436-5bbc-96c2-40638cbb6118"
-version = "0.4.13"
+version = "0.5.3"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -1248,10 +1252,10 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
 
 [[deps.ShaderAbstractions]]
-deps = ["ColorTypes", "FixedPointNumbers", "GeometryBasics", "LinearAlgebra", "Observables", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "79123bc60c5507f035e6d1d9e563bb2971954ec8"
+deps = ["ColorTypes", "FixedPointNumbers", "GeometryBasics", "LinearAlgebra", "Observables", "StaticArrays"]
+git-tree-sha1 = "818554664a2e01fc3784becb2eb3a82326a604b6"
 uuid = "65257c39-d410-5151-9873-9b3e5be5013e"
-version = "0.4.1"
+version = "0.5.0"
 
 [[deps.SharedArrays]]
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
@@ -1376,9 +1380,9 @@ weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
-git-tree-sha1 = "9537ef82c42cdd8c5d443cbc359110cbb36bae10"
+git-tree-sha1 = "5a3a31c41e15a1e042d60f2f4942adccba05d3c9"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.21"
+version = "0.7.0"
 
     [deps.StructArrays.extensions]
     StructArraysAdaptExt = "Adapt"

--- a/examples/demo_boundaryedges.jl
+++ b/examples/demo_boundaryedges.jl
@@ -6,7 +6,7 @@ using Comodo.GeometryBasics
 nSub = 3 # Number of refinement steps of the geodesic sphere
 r = 1.0 # Sphere radius
 F,V = geosphere(nSub,r) # Creating the faces and vertices of a full sphere
-VC = simplexcenter(F,V) # Finding triangle centre coordiantes
+VC = simplexcenter(F,V) # Finding triangle centre coordinates
 F = [F[i] for i in findall(map(v-> v[3]>0,VC))] # Remove some faces using z of central coordinates
 F,V = remove_unused_vertices(F,V) # Cleanup/remove unused vertices after faces were removed
 

--- a/examples/demo_count_edge_face.jl
+++ b/examples/demo_count_edge_face.jl
@@ -6,7 +6,7 @@ using Comodo.GeometryBasics
 nSub = 3 # Number of refinement steps of the geodesic sphere
 r = 1.0 # Sphere radius
 F,V = geosphere(nSub,r) # Creating the faces and vertices of a full sphere
-VC = simplexcenter(F,V) # Finding triangle centre coordiantes
+VC = simplexcenter(F,V) # Finding triangle centre coordinates
 F = [F[i] for i in findall(map(v-> v[3]>0,VC))] # Remove some faces using z of central coordinates
 F,V = remove_unused_vertices(F,V) # Cleanup/remove unused vertices after faces were removed
 

--- a/examples/demo_distmarch.jl
+++ b/examples/demo_distmarch.jl
@@ -35,7 +35,7 @@ elseif testCase==3
 elseif testCase==4
     r = 1.0
     F,V = quadsphere(3,r)    
-elseif testCase==5 # Unmerged STL, each triangle is seperate group
+elseif testCase==5 # Unmerged STL, each triangle is separate group
     # Loading a mesh
     fileName_mesh = joinpath(comododir(),"assets","stl","stanford_bunny_low.stl")
     M = load(fileName_mesh)

--- a/examples/demo_edges2curve.jl
+++ b/examples/demo_edges2curve.jl
@@ -28,7 +28,7 @@ elseif testCase == 3 # Partial non-closed curve (cut hemisphere with bottom edge
     nSub = 2 # Number of refinement steps of the geodesic sphere
     r = 1.0 # Sphere radius
     F,V = hemisphere(nSub,r) # Creating the faces and vertices of a full sphere
-    VC = simplexcenter(F,V) # Finding triangle centre coordiantes
+    VC = simplexcenter(F,V) # Finding triangle centre coordinates
     F = [F[i] for i in findall(map(v-> v[1]>0,VC))] # Remove some faces using z of central coordinates
     F,V = remove_unused_vertices(F,V) # Cleanup/remove unused vertices after faces were removed
     # invert_faces!(F)
@@ -36,7 +36,7 @@ elseif testCase == 3 # Partial non-closed curve (cut hemisphere with bottom edge
     # Using `boundaryedges` to find the boundary edges (edges only touching one face)
     Eb = boundaryedges(F)
     
-    VC = simplexcenter(Eb,V) # Finding triangle centre coordiantes
+    VC = simplexcenter(Eb,V) # Finding triangle centre coordinates
     Eb = [Eb[i] for i in findall(map(v-> v[3]>tol_level,VC))] # Remove some faces using z of central coordinates
     
 end 

--- a/examples/demo_kabsch_rot.jl
+++ b/examples/demo_kabsch_rot.jl
@@ -6,8 +6,8 @@ using FileIO
 
 #=
 This demo is for the `kabsch_rot` function. The Kabsch method allows one to 
-determine the rotation that occured between two meshes (or point sets) with 
-point-to-point correspondance. In this demo a triangulated surface is loaded 
+determine the rotation that occurred between two meshes (or point sets) with 
+point-to-point correspondence. In this demo a triangulated surface is loaded 
 from an STL file. Next the coordinates are rotated, and the Kabsch method is 
 used to retrieve the rotation performed, allowing one to "unrotate" the data.  
 =#

--- a/examples/demo_mesh_curvature_polynomial.jl
+++ b/examples/demo_mesh_curvature_polynomial.jl
@@ -59,7 +59,7 @@ elseif testCase == 8
     nSub = 4 # Number of refinement steps of the geodesic sphere
     r = 2.5 # Sphere radius
     F,V = geosphere(nSub,r) # Creating the faces and vertices of a full sphere
-    VC = simplexcenter(F,V) # Finding triangle centre coordiantes
+    VC = simplexcenter(F,V) # Finding triangle centre coordinates
     F = [F[i] for i in findall(map(v-> v[3]>0,VC))] # Remove some faces using z of central coordinates
     F,V = remove_unused_vertices(F,V) # Cleanup/remove unused vertices after faces were removed
 end

--- a/examples/demo_meshgroup.jl
+++ b/examples/demo_meshgroup.jl
@@ -63,7 +63,7 @@ elseif testCase==5
             end
         end
     end
-elseif testCase==6 # Unmerged STL, each triangle is seperate group
+elseif testCase==6 # Unmerged STL, each triangle is separate group
     # Loading a mesh
     fileName_mesh = joinpath(comododir(),"assets","stl","stanford_bunny_low.stl")
     M = load(fileName_mesh)

--- a/examples/demo_rhombicdodecahedronfoam.jl
+++ b/examples/demo_rhombicdodecahedronfoam.jl
@@ -4,7 +4,7 @@ using Comodo.GeometryBasics
 
 w = 1.0
 n = (3,4,5)
-E,V = rhombicdodecahedronfoam(w,n; merge=false, orientation=:allign)
+E,V = rhombicdodecahedronfoam(w,n; merge=false, orientation=:align)
 F = element2faces(E)
 
 ## Visualize mesh

--- a/examples/demo_subquad.jl
+++ b/examples/demo_subquad.jl
@@ -21,7 +21,7 @@ elseif testCase == 3 # Quadrangulated hemi-sphere
     n = 1
     r = 1.0
     F,V = quadsphere(n,r)
-    VC = simplexcenter(F,V) # Finding triangle centre coordiantes
+    VC = simplexcenter(F,V) # Finding triangle centre coordinates
     F = [F[i] for i in findall(map(v-> v[3]>0,VC))] # Remove some faces using z of central coordinates
     F,V = remove_unused_vertices(F,V) # Cleanup/remove unused vertices after faces were removed
     M = GeometryBasics.Mesh(V,F)

--- a/examples/example_checker.jl
+++ b/examples/example_checker.jl
@@ -40,7 +40,7 @@ function main()
         @info "Here is the list of problematic files:"
         display(problems)
     else
-        @info "All demos completed succesfully."
+        @info "All demos completed successfully."
     end
 end
 

--- a/src/Comodo.jl
+++ b/src/Comodo.jl
@@ -1,6 +1,6 @@
 module Comodo
 
-# Import required functions and modules from dependancy libraries
+# Import required functions and modules from dependency libraries
 using Statistics: mean, Statistics
 using Distances: euclidean, Distances
 using QuadGK: quadgk, QuadGK

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -273,7 +273,7 @@ Interpolates 1D (curve) data using biharmonic spline interpolation
 # Description
 
 This function uses biharmonic spline interpolation [1], which features radial basis 
-functions. The input is assumed to represent ordered data, i.e. consequtive 
+functions. The input is assumed to represent ordered data, i.e. consecutive 
 unique points on a curve. The curve x-, and y-coordinates are provided through 
 the input parameters `x` and `y` respectively. The third input `xi` defines the 
 sites at which to interpolate. Each of in the input parameters can be either a 
@@ -345,8 +345,8 @@ function interp_biharmonic_spline(x::Union{Vector{T}, AbstractRange{T}},y::Union
             yi = interp_biharmonic(xx,yy,xi)
         end
     elseif extrapolate_method==:constant
-        # Simple constant extrapolation (last/first value is repeated indefinately)
-        Ls = xi.<x[1] # Boolean for points preceeding the start
+        # Simple constant extrapolation (last/first value is repeated indefinitely)
+        Ls = xi.<x[1] # Boolean for points preceding the start
         Ll = xi.>x[end] # Boolean for points after the end
         if any(Ls .|| Ll) # If any points outside of the range were encountered
             yi = Vector{Float64}(undef,length(xi)) # Initialise yi
@@ -406,7 +406,7 @@ end
 """
     nbezier(P,n)
 
-Returns a Bezier spline for the control points P whose order matches the numbe 
+Returns a Bezier spline for the control points P whose order matches the number 
 of control points provided. 
 
 # Description 
@@ -578,7 +578,7 @@ be seen as the same as [2,1] for instance.
 """
 function unique_dict_index(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     # T = eltype(X)
     d = Dict{T,Nothing}() # Use dict to keep track of used values
     xUni = Vector{T}()
@@ -612,7 +612,7 @@ be seen as the same as [2,1] for instance.
 """
 function unique_dict_index_inverse(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     # T = eltype(X)
     d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
@@ -645,14 +645,14 @@ Returns unique values, indices, and counts
 # Description
     
 Returns the unique entries in `X` as well as the indices for them and the counts 
-in terms of how often they occured. 
+in terms of how often they occurred. 
 The optional parameter `sort_entries` (default is `false`) can be set to `true`
 if each entry in X should be sorted, this is helpful to allow the entry [1,2] to 
 be seen as the same as [2,1] for instance.  
 """
 function unique_dict_index_count(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     
     # T = eltype(X)
     d = Dict{T,Int}() # Use dict to keep track of used values
@@ -688,14 +688,14 @@ Returns unique values, indices, inverse indices, and counts
     
 Returns the unique entries in `X` as well as the indices for them and the reverse 
 indices to retrieve the original from the unique entries, and also the counts in 
-terms of how often they occured. 
+terms of how often they occurred. 
 The optional parameter `sort_entries` (default is `false`) can be set to `true`
 if each entry in X should be sorted, this is helpful to allow the entry [1,2] to 
 be seen as the same as [2,1] for instance.  
 """
 function unique_dict_index_inverse_count(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     # T = eltype(X)
     d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
@@ -732,14 +732,14 @@ Returns unique values and counts
 # Description
     
 Returns the unique entries in `X` as well as the counts in terms of how often 
-they occured. 
+they occurred. 
 The optional parameter `sort_entries` (default is `false`) can be set to `true`
 if each entry in X should be sorted, this is helpful to allow the entry [1,2] to 
 be seen as the same as [2,1] for instance.  
 """
 function unique_dict_count(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     # T = eltype(X)
     d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
@@ -777,7 +777,7 @@ be seen as the same as [2,1] for instance.
 """
 function unique_dict_inverse(X::Union{Tuple{Vararg{T, N}}, Array{T, N}}; sort_entries=false) where T <: Any where N
     # Here a normal Dict is used to keep track of unique elements. Normal dicts do not maintain element insertion order. 
-    # Hence the unique indices need to seperately be tracked. 
+    # Hence the unique indices need to separately be tracked. 
     # T = eltype(X)
     d = Dict{T,Int}() # Use dict to keep track of used values
     xUni = Vector{T}()
@@ -871,7 +871,7 @@ Returns unique values and allows users to choose if they also want: sorting, ind
 
 Returns the unique entries in `X`. Depending on the optional parameter choices
 the indices for the unique entries, the reverse indices to retrieve the original
-from the unique entries, as well as counts in terms of how often they occured, 
+from the unique entries, as well as counts in terms of how often they occurred, 
 can be returned. 
 The optional parameter `sort_entries` (default is `false`) can be set to `true`
 if each entry in X should be sorted, this is helpful to allow the entry [1,2] to 
@@ -908,7 +908,7 @@ end
 """
     unique_simplices(F,V=nothing)
 
-Returns unique simplices (such as faces), independant of node order
+Returns unique simplices (such as faces), independent of node order
 
 # Description
     
@@ -1341,7 +1341,7 @@ considered a face
 * `FM::Matrix{TF} where TF<:Integer`, whereby each row is considered a face
 * `Vector{NgonFace{m, OffsetInteger{-1, TF}}} where TF<:Integer`, whereby the 
 special integer type `OffsetInteger{-1, TF}` is converted to `Int`.  
-If the intput is already of the right type this function leaves the input 
+If the input is already of the right type this function leaves the input 
 unchanged.
 """
 function tofaces(FM::Vector{Vector{TF}}) where TF<:Integer
@@ -1446,7 +1446,7 @@ end
 """
     edgecrossproduct(F,V::Vector{Point{ND,T}}) where ND where T<:Real  
 
-Returns the edge cross product, useful for nomal direction and area computations. 
+Returns the edge cross product, useful for normal direction and area computations. 
 
     # Description
 
@@ -1832,7 +1832,7 @@ Returns a geodesic sphere triangulation
 
 This function returns a geodesic sphere triangulation based on the number of
 refinement iterations `n` and the radius `r`. Geodesic spheres (aka Buckminster-Fuller
- spheres) are triangulations of a sphere that have near uniform edge lenghts. 
+ spheres) are triangulations of a sphere that have near uniform edge lengths. 
 The algorithm starts with a regular icosahedron. Next this icosahedron is refined 
 `n` times, while nodes are pushed to a sphere surface with radius `r` at each
 iteration. Two methods are available, i.e. `:linear` (default) and `:Loop` 
@@ -1869,7 +1869,7 @@ Returns a geodesic sphere triangulation
 
 This function returns a geodesic hemispherephere triangulation based on the number of
 refinement iterations `n` and the radius `r`. Geodesic spheres (aka Buckminster-Fuller
- spheres) are triangulations of a sphere that have near uniform edge lenghts. 
+ spheres) are triangulations of a sphere that have near uniform edge lengths. 
 The algorithm starts with a regular icosahedron that is adjusted to generate a half icosahedron. 
 Next this icosahedron is refined  `n` times, while nodes are pushed to a sphere surface with radius `r` at each
 iteration. 
@@ -2129,7 +2129,7 @@ This function computes the face-face connectivity for each face. The input faces
 `F` are used to create a list of faces connected to each face by a shared vertex.
 Additional optional inputs include: the vertices `V`, and the vertex-face 
 connectivity `con_V2F`. In terms of vertices only the number of vertices, i.e. 
-`length(V)` is neede, if `V` is not provided it is assumed that `length(V)` 
+`length(V)` is needed, if `V` is not provided it is assumed that `length(V)` 
 corresponds to the largest index in `F`. The vertex-face connectivity if not
 supplied, will be computed by this function, hence computational time may be saved 
 if it was already computed. 
@@ -3126,7 +3126,7 @@ function quad2tri(F::Vector{QuadFace{TF}},V::Vector{Point{ND,TV}}; convert_metho
 end
 
 function remove_unused_vertices(F,V::Vector{Point{ND,TV}}) where ND where TV<:Real
-    if isempty(F) # If the face set is empty, return all emtpy outputs
+    if isempty(F) # If the face set is empty, return all empty outputs
         Fc = F
         Vc = Vector{Point{ND,TV}}()
         indFix = Vector{Int}()
@@ -3360,8 +3360,8 @@ Converts boundary edges to a curve
 
 # Description
 This function takes a set of boundary edges `Eb`, which may not be ordered e.g.
-consequtively, and returns an ordered set of indices `ind` defining a curve of 
-consequtive points. The function returns empty output if the input edges do not 
+consecutively, and returns an ordered set of indices `ind` defining a curve of 
+consecutive points. The function returns empty output if the input edges do not 
 for a proper curve. 
 """
 function edges2curve(Eb::Vector{LineFace{T}}; remove_last = false) where T <: Integer
@@ -3393,7 +3393,7 @@ function edges2curve(Eb::Vector{LineFace{T}}; remove_last = false) where T <: In
         ind = [Eb[i][1]] # Add first edge point and grow this list
         while !all(seen) # loop until all edges have been visited        
             push!(ind,Eb[i][2]) # Add edge end point (start is already in list)
-            seen[i] = true # Lable current edge as visited       
+            seen[i] = true # Label current edge as visited       
             e_ind = con_E2E[i] # Indices for connected edges
             if length(e_ind)>2 # Branch point detected
                 throw(ErrorException("Invalid edges or branch point detected. Current edge is connected to more than two edges."))    
@@ -3506,7 +3506,7 @@ function extrudecurve(V1::Vector{Point{ND,TV}}; extent=1.0, direction=:positive,
     end
     
     # Create offset point depending on direction of extrude
-    if direction == :positive # Allong n from V1
+    if direction == :positive # Along n from V1
         p = extent.*n
     elseif direction == :negative # Against n from V1
         p = -extent.*n
@@ -3532,7 +3532,7 @@ Groups connected mesh features
  
 # Description
 This function uses the connectivity `con_type` to create a group label `C` for
-each entitiy in `F`. E.g. `C.==1` for the first group and `C.==2`` for the 
+each entity in `F`. E.g. `C.==1` for the first group and `C.==2`` for the 
 second and so on.     
 """
 function meshgroup(F; con_type = :v, indStart=1, stop_at = nothing)
@@ -3604,7 +3604,7 @@ end
 Compute on surface distance
 
 # Description
-This function computes allong mesh-edge distances for the points with the 
+This function computes along mesh-edge distances for the points with the 
 indices contained in `indStart`. 
 """
 function distmarch(F,V::Vector{Point{ND,TV}},indStart; d=nothing, dd=nothing, dist_tol=1e-3,con_V2V=nothing,l=nothing) where ND where TV<:Real
@@ -3703,10 +3703,10 @@ required inputs are as follows:
 `ray_vector` The ray vector which can be `Vector{Point{3, Float64}}` or `Vec3{Float64}`
 
 The following optional input parameters can be provided: 
-`rayType = :ray` (default) or `:line`. This defines wether the vector is treated as a ray (extends indefinately) or as a line (finite length)
+`rayType = :ray` (default) or `:line`. This defines whether the vector is treated as a ray (extends indefinitely) or as a line (finite length)
 `triSide = 1` (default) or `0` or `-1`. 
 When `triSide=1` only the inward intersections are considered, e.g. when the ray or line enters the shape (ray/line is pointing against face normal)
-When `triSide=-1` only the outward intersections are considered, e.g. when the ray or line exits the shape (ray/line is pointing allong face normal)
+When `triSide=-1` only the outward intersections are considered, e.g. when the ray or line exits the shape (ray/line is pointing along face normal)
 When `triSide=0` both inward and outward intersections are considered.
 `tolEps = eps(Float64)` (default) 
 
@@ -3740,7 +3740,7 @@ function ray_triangle_intersect(f::TriangleFace{Int},V::Vector{Point{ND,TV1}},ra
         boolDet = det_vec>tolEps
     elseif triSide == 0 # Both ways
         boolDet = abs(det_vec)>tolEps
-    elseif triSide == -1 # Pointing allong face normals
+    elseif triSide == -1 # Pointing along face normals
         boolDet = det_vec<tolEps
     end
 
@@ -3752,7 +3752,7 @@ function ray_triangle_intersect(f::TriangleFace{Int},V::Vector{Point{ND,TV1}},ra
             s_cross_e1 = cross(s,vec_edge_1)
             v = dot(ray_vector,s_cross_e1)/det_vec
             if v >= 0 && (u+v) <= 1 # On triangle according to both u and v
-                # Allong ray/line coordinates i.e. intersection is at ray_origin + t.*ray_vector 
+                # Along ray/line coordinates i.e. intersection is at ray_origin + t.*ray_vector 
                 t = dot(vec_edge_2,s_cross_e1)/det_vec                      
                 if rayType == :ray || (rayType == :line && t>=0 && t<=1.0)                                                   
                     p = ray_origin .+ t.*ray_vector # same as: push!(P, P1 .+ u.*P21 .+ v.*P31)            
@@ -3897,7 +3897,7 @@ end
     curve_length(V::Vector{Point{ND,TV}}; close_loop=false) where ND where TV<:Real
 
 This function computes the stepwise length of the input curve defined by the ND 
-points in `V`. The output is a vector containining the distance for each point, 
+points in `V`. The output is a vector containing the distance for each point, 
 and the total length therefore the last entry. 
 
 If the optional parameter `close_loop` is set to `true` then it is assumed that
@@ -3927,7 +3927,7 @@ spline interpolator `S` used. The output points can also be retriebed by using:
 Note that the even sampling is defined in terms of the curve length for a 4th 
 order natural B-spline that interpolates the input data. Hence if significant 
 curvature exists for the B-spline between two adjacent data points then the 
-spacing between points in the output may be non-uniform (despite the allong 
+spacing between points in the output may be non-uniform (despite the along 
 B-spline distance being uniform). 
 """
 function evenly_sample(V::Vector{Point{ND,TV}}, n::Int; rtol=1e-8, niter=1, spline_order=4, close_loop=false) where ND where TV<:Real
@@ -4095,7 +4095,7 @@ end
     F,V = sweeploft(Vc,V1,V2; face_type=:quad, num_twist = 0, close_loop=true)   
 
 # Description
-This function implements swept lofting. The start curve `V1` is pulled allong the 
+This function implements swept lofting. The start curve `V1` is pulled along the 
 guide curve `Vc` while also gradually (linearly) morphing into the end curve 
 `V2`. 
 The optional parameter `face_type` (default :quad) defines the type of mesh 
@@ -4144,7 +4144,7 @@ function sweeploft(Vc::Vector{Point{ND,TV}},V1::Vector{Point{ND,TV}},V2::Vector{
     # Rotate V2b to start orientation
     V2b = [Q12*v for v in V2b] 
 
-    # Linearly loft "alligned" sections to create draft intermediate sections
+    # Linearly loft "aligned" sections to create draft intermediate sections
     F,V = loftlinear(V1b,V2b;num_steps=nc,close_loop=close_loop,face_type=face_type)
     
     # Rotating and positioning all sections 
@@ -4254,9 +4254,9 @@ end
 The `batman` function creates points on the curve for the Batman logo. The curve
 is useful for testing surface meshing algorithms since it contains sharp 
 transitions and pointy features. The user requests `n` points on the curve. The
-default forces exactly `n` points which may result in an assymetric curve. To 
+default forces exactly `n` points which may result in an asymmetric curve. To 
 instead force symmetry the user can set the optional parameter `symmetric=true`. 
-In this case the output will be symmetric allong the y-axis, however the number
+In this case the output will be symmetric along the y-axis, however the number
 of points on the curve may have increased (if the input `n` is not even). The
 second optional input is the direction of the curve, i.e. if it is clockwise, 
 `dir=:cw` or anti-clockwise `dir=:acw`. 
@@ -4432,7 +4432,7 @@ end
 
 Generates a multi-region triangle mesh for the input regions. The boundary 
 curves for all regions are contained in the tuple `VT`. Each region to be meshed
-is next defined using a tuple `R` containing indices into the curve typle `VT`. 
+is next defined using a tuple `R` containing indices into the curve tuple `VT`. 
 If an entry in `R` contains only one index then the entire curve domain is 
 meshed. If `R` contains multiple indices then the first index is assumed to be 
 for the outer boundary curve, while all subsequent indices are for boundaries 
@@ -4676,9 +4676,9 @@ function dualclad(F::Vector{NgonFace{N, TF}},V::Vector{Point{ND,TV}},s; connecti
         Fq = Vector{QuadFace{Int}}(undef,length(E_Fs))
         for i in eachindex(E_Fs)
             ii = indReverse[i]
-            if E[i][1] == Eu[ii][1] # A first occurance edge, order matches
+            if E[i][1] == Eu[ii][1] # A first occurrence edge, order matches
                 Fq[i] = (E_Fs[i][2],E_Fs[i][1],Es[ii][1],Es[ii][2])
-            else # A second occurance edge, needs inversion
+            else # A second occurrence edge, needs inversion
                 Fq[i] = (E_Fs[i][2],E_Fs[i][1],Es[ii][2],Es[ii][1])
             end
         end
@@ -5764,7 +5764,7 @@ function eulerchar(F,V=nothing,E=nothing)
 end
 
 """
-    rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :allign) where T<:Real
+    rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :align) where T<:Real
 
 Creates a rhombicdodecahedron foam
 
@@ -5774,9 +5774,9 @@ of cells in each direction. The input is the cell width `w` and a 1-by-3 tuple
 `n` defining the number of cells in each direction. The output consists of the 
 set of rhombic dodecahedron elements `E` and their vertex coordinates `V`. 
 """
-function rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :allign) where T<:Real
+function rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :align) where T<:Real
 
-    if orientation == :allign
+    if orientation == :align
         # Create vertices of single rhombic dodecahedron with "radius" 1
         a = sqrt(2)/2
         b = sqrt(2)/4
@@ -6652,7 +6652,7 @@ input `V`. For a single point the output is a single integer which is:
 If the input is instead a vector of points then the output consists of a 
 corresponding vector of such integers. 
 This implementation differs from [1] in terms of the use of `atol` for 
-approximate equivalance. This helps in more robust labelling of "on polygon" 
+approximate equivalence. This helps in more robust labelling of "on polygon" 
 points.  
 
 # References

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4596,7 +4596,7 @@ end
     Vn = evenly_space(V, pointSpacing; close_loop = false, spline_order = 4) 
     @test isapprox(pointspacingmean(Vn),pointSpacing,atol=eps_level)
 
-    # Must poins in open curve
+    # Must points in open curve
     must_points = [2]
     Vn = evenly_space(V, pointSpacing; close_loop = false, spline_order = 4, must_points = must_points) 
     @test isapprox(pointspacingmean(Vn),pointSpacing,atol=eps_level)
@@ -4660,7 +4660,7 @@ end
     R_kabsch_backward = kabsch_rot(V2,V1)
     V1r = [R_kabsch_backward*v for v in V2]
     @test isapprox(R_kabsch_forward,R_true,atol=eps_level) # Able to retrieve forward rotation
-    @test isapprox(V1r,V1,atol=eps_level) # Check if backward rotation is succesful   
+    @test isapprox(V1r,V1,atol=eps_level) # Check if backward rotation is successful   
 end
 
 @testset "sweeploft" verbose = true begin
@@ -5973,7 +5973,7 @@ end
         [0.0, 0.0, 2.0], [1.0, 1.0, 2.0]],atol=eps_level)        
     end
 
-    @testset "Vector of TriangeFaces" begin       
+    @testset "Vector of TriangleFaces" begin       
         F = TriangleFace{Int}[ [1,2,3], [2,4,3] ]
         V = Point{3,Float64}[ [0.0,0.0,0.0], [1.0,0.0,0.0], [1.0,1.0,0.0], [2.0,0.0,0.0]]
 
@@ -6480,7 +6480,7 @@ end
 
 @testset "rhombicdodecahedronfoam" verbose = true begin
 
-    # rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :allign) where T<:Real
+    # rhombicdodecahedronfoam(w::T,n::Union{Tuple{Vararg{Int, 3}}, Array{Int, 3}}; merge = true, orientation = :align) where T<:Real
     w = 2.1
     n = (3,4,5)
     E,V = rhombicdodecahedronfoam(w,n)
@@ -6492,7 +6492,7 @@ end
     @test isa(V,Vector{Point{3,Float64}})
     @test length(E) == k
 
-    E,V = rhombicdodecahedronfoam(w,n; merge = false, orientation = :allign)
+    E,V = rhombicdodecahedronfoam(w,n; merge = false, orientation = :align)
     @test length(E) == k
     @test length(V) == k*14
     


### PR DESCRIPTION
Fix typos in 

- code
- code comments
- documentation

The keyword `:allign` changes to `:allign`. This change affects an example file in the examples folder, so example checker may fail before a version pump.

